### PR TITLE
Configurable presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,15 +177,15 @@ module.exports = sagui().webpack({
 
 Here is the complete list of existing Sagui presets:
 
-- **archetype-library**: Add support for the above *Library* configuration;
-- **archetype-pages**: Add support for the above *Pages* configuration;
 - **babel**: ES2015 support;
 - **base**: Base paths and webpack plugins;
 - **define-node-env**: Populates `process.env.NODE_ENV`;
 - **eslint**: ESLint support via [Standard](http://standardjs.com/);
-- **images** Images loading support (`jpg`, `jpeg`, `png`, `gif`, `svg`);
 - **fonts**: Font loading support (`woff`, `woff2`, `ttf`, `eot`);
+- **images** Images loading support (`jpg`, `jpeg`, `png`, `gif`, `svg`);
 - **json**: JSON loader;
+- **library**: Add support for the above *Library* configuration;
+- **pages**: Add support for the above *Pages* configuration;
 - **style**: Vanilla CSS and [Sass language](http://sass-lang.com/) with [CSS Modules](https://github.com/css-modules/css-modules) support;
 - **videos**: Videos loading support (`ogg`, `mp4`).
 

--- a/src/webpack/presets/babel.js
+++ b/src/webpack/presets/babel.js
@@ -3,7 +3,7 @@ import sagui from 'babel-preset-sagui'
 
 export default {
   name: 'babel',
-  configure ({ buildTarget }) {
+  configure ({ buildTarget, babel = {} }) {
     const hmrEnv = {
       development: {
         plugins: [
@@ -29,7 +29,8 @@ export default {
           {
             test: /\.jsx?$/,
             exclude: /node_modules/,
-            loader: 'babel'
+            loader: 'babel',
+            ...babel
           }
         ]
       },

--- a/src/webpack/presets/index.js
+++ b/src/webpack/presets/index.js
@@ -1,27 +1,27 @@
 import merge from 'webpack-merge'
 
-import archetypeLibrary from './archetype-library'
-import archetypePages from './archetype-pages'
 import babel from './babel'
 import base from './base'
 import defineNodeENV from './define-node-env'
 import eslint from './eslint'
-import images from './images'
 import fonts from './fonts'
+import images from './images'
 import json from './json'
+import library from './library'
+import pages from './pages'
 import style from './style'
 import videos from './videos'
 
 const presets = [
-  archetypeLibrary,
-  archetypePages,
   babel,
   base,
   defineNodeENV,
   eslint,
-  images,
   fonts,
+  images,
   json,
+  library,
+  pages,
   style,
   videos
 ]

--- a/src/webpack/presets/library.js
+++ b/src/webpack/presets/library.js
@@ -1,7 +1,7 @@
 import { join } from 'path'
 
 export default {
-  name: 'archetype-library',
+  name: 'library',
   configure ({ library, projectPath, buildTarget }) {
     if (!library) { return {} }
 

--- a/src/webpack/presets/library.spec.js
+++ b/src/webpack/presets/library.spec.js
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import { expect } from 'chai'
-import plugin from './archetype-library'
+import plugin from './library'
 
 const saguiPath = join(__dirname, '../../../')
 const projectPath = join(saguiPath, 'spec/fixtures/library-project')

--- a/src/webpack/presets/pages.js
+++ b/src/webpack/presets/pages.js
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { optimize } from 'webpack'
 
 export default {
-  name: 'archetype-pages',
+  name: 'pages',
   configure ({ pages = [], buildTarget, projectPath }) {
     if (pages.length === 0) { return {} }
 

--- a/src/webpack/presets/pages.spec.js
+++ b/src/webpack/presets/pages.spec.js
@@ -2,7 +2,7 @@ import HtmlWebpackPlugin from 'html-webpack-plugin'
 import { optimize } from 'webpack'
 import { expect } from 'chai'
 
-import plugin from './archetype-pages'
+import plugin from './pages'
 
 const projectPath = '/tmp/projec-path'
 


### PR DESCRIPTION
This is just an idea at this moment...

```js
var sagui = require('sagui')

module.exports = sagui().webpack({
  sagui: {
    babel: {
      include: [
        path.resolve(path.join(__dirname, 'node_modules')),
        path.resolve(path.join(__dirname, 'fixtures')),
        path.resolve(path.join(__dirname, 'src'))
      ]
    },
  }
})
```

In a way, `pages` and `library` are already configurable presets 😄 .