### PR TITLE
Change build target folder back to `dist` 😳

### DIFF
--- a/src/webpack/presets/clean.js
+++ b/src/webpack/presets/clean.js
@@ -5,7 +5,7 @@ export default {
   configure ({ projectPath }) {
     return {
       plugins: [
-        new CleanWebpackPlugin(['build'], {
+        new CleanWebpackPlugin(['dist'], {
           root: projectPath,
           verbose: false
         })

--- a/src/webpack/presets/clean.spec.js
+++ b/src/webpack/presets/clean.spec.js
@@ -11,7 +11,7 @@ describe('clean webpack preset', function () {
     expect(commons.length).equal(1)
 
     const cleanWebpackPlugin = commons[0]
-    expect(cleanWebpackPlugin.paths).to.eql(['build'])
+    expect(cleanWebpackPlugin.paths).to.eql(['dist'])
     expect(cleanWebpackPlugin.options.verbose).to.eql(false)
     expect(cleanWebpackPlugin.options.root).to.eql(projectPath)
   })

--- a/src/webpack/presets/library.js
+++ b/src/webpack/presets/library.js
@@ -11,7 +11,7 @@ export default {
     return {
       entry: './index.js',
       output: {
-        path: join(projectPath, 'build'),
+        path: join(projectPath, 'dist'),
         filename: 'index.js',
         libraryTarget: buildTarget === buildTargets.TEST ? undefined : 'commonjs2',
         library

--- a/src/webpack/presets/library.spec.js
+++ b/src/webpack/presets/library.spec.js
@@ -36,7 +36,7 @@ describe('library webpack preset', function () {
 
     it('should have the output path configured as the build folder', function () {
       const webpackConfig = preset.configure(baseConfiguration)
-      expect(webpackConfig.output.path).eql(join(projectPath, 'build'))
+      expect(webpackConfig.output.path).eql(join(projectPath, 'dist'))
     })
 
     describe('externals', function () {

--- a/src/webpack/presets/pages.js
+++ b/src/webpack/presets/pages.js
@@ -13,7 +13,7 @@ export default {
 
     return {
       output: {
-        path: join(projectPath, 'build'),
+        path: join(projectPath, 'dist'),
         filename: '[name]-[hash].js',
         chunkFilename: '[name]-[hash].chunk.js'
       },

--- a/src/webpack/presets/pages.spec.js
+++ b/src/webpack/presets/pages.spec.js
@@ -26,7 +26,7 @@ describe('pages webpack preset', function () {
 
     it('should have the output path configured as the build folder', function () {
       const webpackConfig = preset.configure(baseConfig)
-      expect(webpackConfig.output.path).eql('/tmp/projec-path/build')
+      expect(webpackConfig.output.path).eql('/tmp/projec-path/dist')
     })
 
     it('should have the entrypoints setup with the index', function () {

--- a/template/dot-files/gitignore
+++ b/template/dot-files/gitignore
@@ -1,4 +1,4 @@
 coverage
 node_modules
 npm-debug.log
-build
+dist


### PR DESCRIPTION
This was recently changed from `dist` to `build` in the v6 branch, but we decided to rollback that decision:

- Makes it easy to people with CI scripts to migrate to the new version;
- We usually want to build a "distribution" of the app, so the name is more suiting anyway.