### PR TITLE
Build JavaScript dependencies when configured 🔨

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import pipeline from './util/pipeline'
  * @param {string} options.projectPath Full path of the root directory of the project being built.
  * @param {string} options.buildTarget Target: (development, production, test).
  * @param {string} options.action Action: (develop, test, build)
+ * @param {string[]} [options.javaScript.buildDependencies = true] Which dependencies to transpile (Ex: ['ui-react-components'])
  * @param {boolean} [options.hotReloading = true] Enable hot reloading
  * @param {boolean} [options.optimize = false] Optimize the output (minify, dedup...)
  * @param {boolean} [options.defineNodeEnv = true] Define and replace NODE_ENV environment in the code
@@ -62,6 +63,7 @@ const DEFAULT_OPTIONS = {
   lint: true,
   pages: ['/index'],
   disabledLoaders: [],
+  javaScript: {},
   webpack: {},
   karma: {}
 }

--- a/src/webpack/presets/babel.js
+++ b/src/webpack/presets/babel.js
@@ -20,7 +20,7 @@ export default {
       }
     }
 
-    const userPaths = (javaScript.buildDependencies || []).map((dependency) => (
+    const userPaths = (javaScript.transpileDependencies || []).map((dependency) => (
       path.join(projectPath, 'node_modules', dependency)
     ))
 

--- a/src/webpack/presets/babel.js
+++ b/src/webpack/presets/babel.js
@@ -5,7 +5,7 @@ import buildTargets from '../../build-targets'
 
 export default {
   name: 'babel',
-  configure ({ buildTarget, projectPath }) {
+  configure ({ buildTarget, projectPath, javaScript = {} }) {
     const hmrEnv = {
       development: {
         plugins: [
@@ -20,6 +20,10 @@ export default {
       }
     }
 
+    const userPaths = (javaScript.buildDependencies || []).map((dependency) => (
+      path.join(projectPath, 'node_modules', dependency)
+    ))
+
     return {
       babel: {
         babelrc: path.join(projectPath, '.babelrc'),
@@ -30,7 +34,10 @@ export default {
         loaders: [
           {
             test: fileExtensions.JAVASCRIPT,
-            exclude: /node_modules/,
+            include: [
+              path.join(projectPath, 'src'),
+              ...userPaths
+            ],
             loader: 'babel'
           }
         ]

--- a/src/webpack/presets/babel.spec.js
+++ b/src/webpack/presets/babel.spec.js
@@ -13,7 +13,7 @@ describe('babel', () => {
     const config = {
       projectPath,
       javaScript: {
-        buildDependencies: [
+        transpileDependencies: [
           // an example project
           'ui-react-components'
         ]

--- a/src/webpack/presets/babel.spec.js
+++ b/src/webpack/presets/babel.spec.js
@@ -1,0 +1,29 @@
+import { expect } from 'chai'
+import preset from './babel'
+
+describe('babel', () => {
+  const projectPath = '/tmp/test-project'
+
+  it('should only build files inside the src folder by default', () => {
+    const webpack = preset.configure({ projectPath })
+    expect(webpack.module.loaders[0].include).to.eql(['/tmp/test-project/src'])
+  })
+
+  it('should include the user defined dependencies to be built', () => {
+    const config = {
+      projectPath,
+      javaScript: {
+        buildDependencies: [
+          // an example project
+          'ui-react-components'
+        ]
+      }
+    }
+
+    const webpack = preset.configure(config)
+    expect(webpack.module.loaders[0].include).to.eql([
+      '/tmp/test-project/src',
+      '/tmp/test-project/node_modules/ui-react-components'
+    ])
+  })
+})


### PR DESCRIPTION
What do you think is the best name for the configuration parameter? I'm not sure build is clear enough, given we are building the hole project.

I was thinking on maybe naming the config as:

```js
{
  javaScript: {
    transpileDependencies: ['ui-react-components']
  }
}
```

Any other ideas?

This closes #126 