### PR TITLE
Run integration tests as a separated test suite 👥

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,16 @@ node_js:
 sudo: false
 script:
 - |
-    if [ "$TEST_TYPE" = unit_test ]; then
+    if [ "$TEST_TYPE" = lint_and_test_unit ]; then
       set -e
-      npm test
+      npm run test:lint
+      npm run test:unit
 
     elif [ "$TEST_TYPE" = integration_test ]; then
+      set -e
+      npm run test:integration
+
+    elif [ "$TEST_TYPE" = test_create_project ]; then
       set -e
 
       SAGUI_DIR=`pwd`
@@ -28,8 +33,9 @@ script:
     fi
 env:
   matrix:
-  - TEST_TYPE=unit_test
+  - TEST_TYPE=lint_and_test_unit
   - TEST_TYPE=integration_test
+  - TEST_TYPE=test_create_project
 cache:
   directories:
     - node_modules

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:lint": "eslint .",
     "test:integration": "mocha --timeout 0 --compilers js:babel-register --recursive --reporter spec --fgrep [integration] ./src",
     "test:unit": "mocha --timeout 0 --compilers js:babel-register --recursive --reporter spec --fgrep [integration] --invert ./src",
-    "test:unit-watch": "npm run test:unit -- --watch",
+    "test:unit:watch": "npm run test:unit -- --watch",
     "prepublish": "not-in-install && npm prune && npm test && npm run build || in-install",
     "postinstall": "./bin/sagui install"
   },

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
   ],
   "scripts": {
     "build": "rm -rf lib && babel src --out-dir lib --ignore *.spec.js",
-    "test": "npm run test:lint && npm run test:unit",
+    "test": "npm run test:lint && npm run test:unit && npm run test:integration",
     "test:lint": "eslint .",
-    "test:unit": "mocha --timeout 0 --compilers js:babel-register --recursive --reporter spec ./src",
+    "test:integration": "mocha --timeout 0 --compilers js:babel-register --recursive --reporter spec --fgrep [integration] ./src",
+    "test:unit": "mocha --timeout 0 --compilers js:babel-register --recursive --reporter spec --fgrep [integration] --invert ./src",
     "test:unit-watch": "npm run test:unit -- --watch",
     "prepublish": "not-in-install && npm prune && npm test && npm run build || in-install",
     "postinstall": "./bin/sagui install"

--- a/src/index.integration-spec.js
+++ b/src/index.integration-spec.js
@@ -3,7 +3,7 @@ import path from 'path'
 import { expect } from 'chai'
 import sagui from '.'
 
-describe('sagui', function () {
+describe('[integration] sagui', function () {
   describe('simple project', () => {
     const projectFixture = path.join(__dirname, '../spec/fixtures/simple-project')
     const projectPath = path.join(__dirname, '../tmp/project')


### PR DESCRIPTION
This will allow us to more quickly iterate on the unit tests with "watch" and implement a more comprehensive set of integration tests.

I've also renamed the Travis "jobs" and made everything run in parallel there.