### PR TITLE
Enable HMR only on develop action

### DIFF
--- a/src/webpack/loaders/javascript.js
+++ b/src/webpack/loaders/javascript.js
@@ -32,6 +32,10 @@ export default {
 
       plugins: action === 'develop' ? [new HotModuleReplacementPlugin()] : [],
 
+      resolve: {
+        extensions: ['.js', '.jsx', '.es6']
+      },
+
       module: {
         loaders: [
           {

--- a/src/webpack/loaders/javascript.js
+++ b/src/webpack/loaders/javascript.js
@@ -1,11 +1,11 @@
+import { HotModuleReplacementPlugin } from 'webpack'
 import path from 'path'
 import reactTransform from 'babel-plugin-react-transform'
 import fileExtensions from '../../file-extensions'
-import buildTargets from '../../build-targets'
 
 export default {
   name: 'javaScript',
-  configure ({ buildTarget, projectPath, javaScript = {} }) {
+  configure ({ action, projectPath, javaScript = {} }) {
     const hmrEnv = {
       development: {
         plugins: [
@@ -27,8 +27,10 @@ export default {
     return {
       babel: {
         babelrc: path.join(projectPath, '.babelrc'),
-        env: buildTarget === buildTargets.DEVELOPMENT ? hmrEnv : {}
+        env: action === 'develop' ? hmrEnv : {}
       },
+
+      plugins: action === 'develop' ? [new HotModuleReplacementPlugin()] : [],
 
       module: {
         loaders: [

--- a/src/webpack/loaders/javascript.spec.js
+++ b/src/webpack/loaders/javascript.spec.js
@@ -29,6 +29,11 @@ describe('javaScript', () => {
     ])
   })
 
+  it('should resolve js, jsx and es6 files', function () {
+    const webpack = loader.configure({ projectPath })
+    expect(webpack.resolve.extensions).to.eql(['.js', '.jsx', '.es6'])
+  })
+
   describe('HMR', () => {
     it('should not setup any babel plugin by default', () => {
       const webpack = loader.configure({ projectPath })

--- a/src/webpack/loaders/javascript.spec.js
+++ b/src/webpack/loaders/javascript.spec.js
@@ -1,3 +1,5 @@
+import { HotModuleReplacementPlugin } from 'webpack'
+import reactTransform from 'babel-plugin-react-transform'
 import { expect } from 'chai'
 import loader from './javascript'
 
@@ -25,5 +27,29 @@ describe('javaScript', () => {
       '/tmp/test-project/src',
       '/tmp/test-project/node_modules/ui-react-components'
     ])
+  })
+
+  describe('HMR', () => {
+    it('should not setup any babel plugin by default', () => {
+      const webpack = loader.configure({ projectPath })
+      expect(webpack.babel.env).to.eql({})
+    })
+
+    it('should not setup any webpack plugin by default', () => {
+      const webpack = loader.configure({ projectPath })
+      expect(webpack.plugins).to.eql([])
+    })
+
+    it('should setup react transform babel plugin if action is develop', () => {
+      const webpack = loader.configure({ projectPath, action: 'develop' })
+      expect(webpack.babel.env.development.plugins[0][0]).to.equal(reactTransform)
+    })
+
+    it('should setup the HotModuleReplacementPlugin if action is develop', () => {
+      const webpack = loader.configure({ projectPath, action: 'develop' })
+
+      const plugins = webpack.plugins.filter((plugin) => plugin instanceof HotModuleReplacementPlugin)
+      expect(plugins.length).equal(1)
+    })
   })
 })

--- a/src/webpack/presets/base.js
+++ b/src/webpack/presets/base.js
@@ -3,7 +3,7 @@ import path from 'path'
 
 export default {
   name: 'base',
-  configure ({ buildTarget, projectPath, saguiPath }) {
+  configure ({ projectPath, saguiPath }) {
     const projectSourcePath = path.join(projectPath, 'src')
 
     return {
@@ -14,7 +14,8 @@ export default {
       plugins: [new NoErrorsPlugin()],
 
       resolve: {
-        extensions: ['', '.js', '.jsx', '.es6'],
+        extensions: [''],
+
         root: [
           path.join(projectPath, '/node_modules'),
           projectSourcePath,

--- a/src/webpack/presets/base.js
+++ b/src/webpack/presets/base.js
@@ -1,6 +1,5 @@
-import { HotModuleReplacementPlugin, NoErrorsPlugin } from 'webpack'
+import { NoErrorsPlugin } from 'webpack'
 import path from 'path'
-import buildTargets from '../../build-targets'
 
 export default {
   name: 'base',
@@ -12,7 +11,7 @@ export default {
 
       devtool: 'source-map',
 
-      plugins: buildPlugins(buildTarget),
+      plugins: [new NoErrorsPlugin()],
 
       resolve: {
         extensions: ['', '.js', '.jsx', '.es6'],
@@ -36,17 +35,4 @@ export default {
       }
     }
   }
-}
-
-function buildPlugins (buildTarget) {
-  const plugins = [
-    // prevent assets emitted that include errors
-    new NoErrorsPlugin()
-  ]
-
-  if (buildTarget === buildTargets.DEVELOPMENT) {
-    plugins.push(new HotModuleReplacementPlugin())
-  }
-
-  return plugins
 }

--- a/src/webpack/presets/base.spec.js
+++ b/src/webpack/presets/base.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { join } from 'path'
-import { HotModuleReplacementPlugin, NoErrorsPlugin } from 'webpack'
+import { NoErrorsPlugin } from 'webpack'
 import preset from './base'
 import buildTargets from '../../build-targets'
 
@@ -29,14 +29,5 @@ describe('base webpack preset', function () {
 
     const commons = config.plugins.filter((plugin) => plugin instanceof NoErrorsPlugin)
     expect(commons.length).equal(1)
-  })
-
-  describe('development build target', function () {
-    it('should configure HotModuleReplacementPlugin', function () {
-      const config = preset.configure({ projectPath, saguiPath, buildTarget: buildTargets.DEVELOPMENT })
-
-      const commons = config.plugins.filter((plugin) => plugin instanceof HotModuleReplacementPlugin)
-      expect(commons.length).equal(1)
-    })
   })
 })

--- a/src/webpack/presets/base.spec.js
+++ b/src/webpack/presets/base.spec.js
@@ -2,14 +2,13 @@ import { expect } from 'chai'
 import { join } from 'path'
 import { NoErrorsPlugin } from 'webpack'
 import preset from './base'
-import buildTargets from '../../build-targets'
 
 const saguiPath = join(__dirname, '../../../../../')
 const projectPath = join(saguiPath, 'spec/fixtures/simple-project')
 
 describe('base webpack preset', function () {
   it('should add the project\'s `src/` and `node_modules/` to root resolve', function () {
-    const config = preset.configure({ projectPath, saguiPath, buildTarget: buildTargets.PRODUCTION })
+    const config = preset.configure({ projectPath, saguiPath })
 
     expect(config.resolve.root).to.eql([
       join(projectPath, '/node_modules'),
@@ -18,14 +17,13 @@ describe('base webpack preset', function () {
     ])
   })
 
-  it('should resolve jsx files', function () {
-    const config = preset.configure({ projectPath, saguiPath, buildTarget: buildTargets.PRODUCTION })
-
-    expect(config.resolve.extensions).to.eql(['', '.js', '.jsx', '.es6'])
+  it('should resolve files without extension', function () {
+    const config = preset.configure({ projectPath, saguiPath })
+    expect(config.resolve.extensions).to.eql([''])
   })
 
   it('should configure NoErrorsPlugin to prevent assets with erros from being emitted', function () {
-    const config = preset.configure({ projectPath, saguiPath, buildTarget: buildTargets.PRODUCTION })
+    const config = preset.configure({ projectPath, saguiPath })
 
     const commons = config.plugins.filter((plugin) => plugin instanceof NoErrorsPlugin)
     expect(commons.length).equal(1)


### PR DESCRIPTION
We are currently enabling it based on the environment, which makes us bundle HMR code while running `npm run build`