### PR TITLE
Add support to build multiple libraries 👩‍👩‍👧‍👧

### DIFF
--- a/src/webpack/archetypes/library.js
+++ b/src/webpack/archetypes/library.js
@@ -1,6 +1,17 @@
 import { join } from 'path'
 import buildTargets from '../../build-targets'
 
+/**
+ * Defines how to build a single library.
+ *
+ * The library parameter is both the name of the file
+ * is the src/ directory and also the name of the built
+ * artefact.
+ *
+ * To find more information about how the original configuration
+ * parameter `libraries` turns into a single `library`, check
+ * the function `splitArchetypes`.
+ */
 export default {
   name: 'library',
   configure ({ library, projectPath, buildTarget }) {
@@ -9,12 +20,11 @@ export default {
     const externals = probeExternals(projectPath)
 
     return {
-      entry: './index.js',
+      entry: `./${library}.js`,
       output: {
         path: join(projectPath, 'dist'),
-        filename: 'index.js',
-        libraryTarget: buildTarget === buildTargets.TEST ? undefined : 'commonjs2',
-        library
+        filename: `${library}.js`,
+        libraryTarget: buildTarget === buildTargets.TEST ? undefined : 'commonjs2'
       },
       externals: buildTarget === buildTargets.TEST ? [] : externals
     }

--- a/src/webpack/archetypes/library.spec.js
+++ b/src/webpack/archetypes/library.spec.js
@@ -10,7 +10,7 @@ const projectWithoutPeerDependenciesPath = join(saguiPath, 'spec/fixtures/librar
 describe('library webpack preset', function () {
   describe('simple name configuration', function () {
     const baseConfiguration = {
-      library: 'FancyLibrary',
+      library: 'index',
       projectPath
     }
 

--- a/src/webpack/split-archetypes.js
+++ b/src/webpack/split-archetypes.js
@@ -1,18 +1,29 @@
 /**
  * Given one configuration object, it returns and array of more than one
  * with archetype specific configuration
+ *
+ * This a requirement because when we build libraries, we can only have a
+ * single entry-point in the webpack configuration.
+ *
+ * This function turns { libraries } into { library }, check the tests for
+ * more information.
  */
 export default function (saguiOptions) {
   const archetypes = []
 
-  const { pages, library, ...otherOptions } = saguiOptions
+  const { pages, libraries, ...otherOptions } = saguiOptions
 
   if (pages && pages.length > 0) {
     archetypes.push({ pages, ...otherOptions })
   }
 
-  if (library && Object.keys(library).length > 0) {
-    archetypes.push({ library, ...otherOptions })
+  if (libraries && libraries.length > 0) {
+    libraries.forEach((library) => {
+      archetypes.push({
+        library,
+        ...otherOptions
+      })
+    })
   }
 
   return archetypes

--- a/src/webpack/split-archetypes.spec.js
+++ b/src/webpack/split-archetypes.spec.js
@@ -1,0 +1,38 @@
+import { expect } from 'chai'
+import splitArchetypes from './split-archetypes'
+
+describe('splitArchetypes', () => {
+  it('should return a single configuration for all pages', () => {
+    const config = {
+      pages: ['index', 'demo']
+    }
+
+    expect(splitArchetypes(config)).to.eql([
+      { pages: ['index', 'demo'] }
+    ])
+  })
+
+  it('should return a different configuration for each library', () => {
+    const config = {
+      libraries: ['index', 'demo']
+    }
+
+    expect(splitArchetypes(config)).to.eql([
+      { library: 'index' },
+      { library: 'demo' }
+    ])
+  })
+
+  it('should mix both archetypes', () => {
+    const config = {
+      pages: ['index', 'demo'],
+      libraries: ['index', 'demo']
+    }
+
+    expect(splitArchetypes(config)).to.eql([
+      { pages: ['index', 'demo'] },
+      { library: 'index' },
+      { library: 'demo' }
+    ])
+  })
+})


### PR DESCRIPTION
# New configuration

We can now configure Sagui with:

```js
{
  libraries: [‘index’, ‘batata’, ‘macaco’]
}
```

And it will build the following files (just like the pages does) as individual libraries in the `dist` folder.

# Implementation detail 

To work properly, we need to split the original configuration into multiple webpack configurations.

Fixes #56 