### PR TITLE
Use file extensions everywhere

### DIFF
--- a/src/file-extensions.js
+++ b/src/file-extensions.js
@@ -2,7 +2,7 @@ export default {
   list: {
     JAVASCRIPT: ['.js', '.jsx', '.es6']
   },
-  pattern: {
+  test: {
     CSS: /\.css$/,
     EOT: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
     IMAGE: /\.(png|jpg|jpeg|gif|svg)$/,

--- a/src/file-extensions.js
+++ b/src/file-extensions.js
@@ -1,13 +1,18 @@
 export default {
-  CSS: /\.css$/,
-  EOT: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
-  IMAGE: /\.(png|jpg|jpeg|gif|svg)$/,
-  JAVASCRIPT: /\.(jsx?|es6)$/,
-  JSON: /\.(json)$/,
-  SCSS: /\.scss$/,
-  TTF: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-  VIDEO: /\.(ogg|mp4)$/,
-  WOFF2: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
-  WOFF: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
-  YAML: /\.(yml|yaml)$/
+  list: {
+    JAVASCRIPT: ['.js', '.jsx', '.es6']
+  },
+  pattern: {
+    CSS: /\.css$/,
+    EOT: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
+    IMAGE: /\.(png|jpg|jpeg|gif|svg)$/,
+    JAVASCRIPT: /\.(jsx?|es6)$/,
+    JSON: /\.(json)$/,
+    SCSS: /\.scss$/,
+    TTF: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
+    VIDEO: /\.(ogg|mp4)$/,
+    WOFF2: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
+    WOFF: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
+    YAML: /\.(yml|yaml)$/
+  }
 }

--- a/src/runner/lint.js
+++ b/src/runner/lint.js
@@ -1,9 +1,10 @@
 import eslint from 'eslint'
 import { logError, log } from '../util/log'
+import fileExtensions from '../file-extensions'
 
 export default ({ projectPath }) => new Promise((resolve, reject) => {
   const cli = new eslint.CLIEngine({
-    extensions: ['.es6', '.js', '.jsx']
+    extensions: fileExtensions.list.JAVASCRIPT
   })
 
   const report = cli.executeOnFiles([projectPath])

--- a/src/webpack/index.spec.js
+++ b/src/webpack/index.spec.js
@@ -60,7 +60,7 @@ describe('webpack', function () {
           module: {
             loaders: [
               {
-                test: fileExtensions.pattern.JAVASCRIPT,
+                test: fileExtensions.test.JAVASCRIPT,
                 loader: 'babel'
               }
             ]

--- a/src/webpack/index.spec.js
+++ b/src/webpack/index.spec.js
@@ -60,7 +60,7 @@ describe('webpack', function () {
           module: {
             loaders: [
               {
-                test: fileExtensions.JAVASCRIPT,
+                test: fileExtensions.pattern.JAVASCRIPT,
                 loader: 'babel'
               }
             ]

--- a/src/webpack/loaders/font.js
+++ b/src/webpack/loaders/font.js
@@ -7,19 +7,19 @@ export default {
       module: {
         loaders: [
           {
-            test: fileExtensions.pattern.WOFF,
+            test: fileExtensions.test.WOFF,
             loader: 'file?name=[name]-[hash].[ext]&mimetype=application/font-woff'
           },
           {
-            test: fileExtensions.pattern.WOFF2,
+            test: fileExtensions.test.WOFF2,
             loader: 'file?name=[name]-[hash].[ext]&mimetype=application/font-woff'
           },
           {
-            test: fileExtensions.pattern.TTF,
+            test: fileExtensions.test.TTF,
             loader: 'file?name=[name]-[hash].[ext]&mimetype=application/octet-stream'
           },
           {
-            test: fileExtensions.pattern.EOT,
+            test: fileExtensions.test.EOT,
             loader: 'file?name=[name]-[hash].[ext]'
           }
         ]

--- a/src/webpack/loaders/font.js
+++ b/src/webpack/loaders/font.js
@@ -7,19 +7,19 @@ export default {
       module: {
         loaders: [
           {
-            test: fileExtensions.WOFF,
+            test: fileExtensions.pattern.WOFF,
             loader: 'file?name=[name]-[hash].[ext]&mimetype=application/font-woff'
           },
           {
-            test: fileExtensions.WOFF2,
+            test: fileExtensions.pattern.WOFF2,
             loader: 'file?name=[name]-[hash].[ext]&mimetype=application/font-woff'
           },
           {
-            test: fileExtensions.TTF,
+            test: fileExtensions.pattern.TTF,
             loader: 'file?name=[name]-[hash].[ext]&mimetype=application/octet-stream'
           },
           {
-            test: fileExtensions.EOT,
+            test: fileExtensions.pattern.EOT,
             loader: 'file?name=[name]-[hash].[ext]'
           }
         ]

--- a/src/webpack/loaders/image.js
+++ b/src/webpack/loaders/image.js
@@ -7,7 +7,7 @@ export default {
       module: {
         loaders: [
           {
-            test: fileExtensions.pattern.IMAGE,
+            test: fileExtensions.test.IMAGE,
             loader: 'url-loader?limit=8192&name=[name]-[hash].[ext]'
           }
         ]

--- a/src/webpack/loaders/image.js
+++ b/src/webpack/loaders/image.js
@@ -7,7 +7,7 @@ export default {
       module: {
         loaders: [
           {
-            test: fileExtensions.IMAGE,
+            test: fileExtensions.pattern.IMAGE,
             loader: 'url-loader?limit=8192&name=[name]-[hash].[ext]'
           }
         ]

--- a/src/webpack/loaders/javascript.js
+++ b/src/webpack/loaders/javascript.js
@@ -40,7 +40,7 @@ export default {
       module: {
         loaders: [
           {
-            test: fileExtensions.pattern.JAVASCRIPT,
+            test: fileExtensions.test.JAVASCRIPT,
             include: [
               path.join(projectPath, 'src'),
               ...userPaths

--- a/src/webpack/loaders/javascript.js
+++ b/src/webpack/loaders/javascript.js
@@ -34,13 +34,13 @@ export default {
       plugins: action === actions.DEVELOP ? [new HotModuleReplacementPlugin()] : [],
 
       resolve: {
-        extensions: ['.js', '.jsx', '.es6']
+        extensions: fileExtensions.list.JAVASCRIPT
       },
 
       module: {
         loaders: [
           {
-            test: fileExtensions.JAVASCRIPT,
+            test: fileExtensions.pattern.JAVASCRIPT,
             include: [
               path.join(projectPath, 'src'),
               ...userPaths

--- a/src/webpack/loaders/javascript.spec.js
+++ b/src/webpack/loaders/javascript.spec.js
@@ -2,6 +2,7 @@ import { HotModuleReplacementPlugin } from 'webpack'
 import reactTransform from 'babel-plugin-react-transform'
 import { expect } from 'chai'
 import loader from './javascript'
+import fileExtensions from '../../file-extensions'
 import actions from '../../actions'
 
 describe('javaScript', () => {
@@ -30,9 +31,9 @@ describe('javaScript', () => {
     ])
   })
 
-  it('should resolve js, jsx and es6 files', function () {
+  it(`should resolve JavaScript files (${fileExtensions.list.JAVASCRIPT})`, function () {
     const webpack = loader.configure({ projectPath })
-    expect(webpack.resolve.extensions).to.eql(['.js', '.jsx', '.es6'])
+    expect(webpack.resolve.extensions).to.eql(fileExtensions.list.JAVASCRIPT)
   })
 
   describe('HMR', () => {

--- a/src/webpack/loaders/json.js
+++ b/src/webpack/loaders/json.js
@@ -7,7 +7,7 @@ export default {
       module: {
         loaders: [
           {
-            test: fileExtensions.pattern.JSON,
+            test: fileExtensions.test.JSON,
             loader: 'json-loader'
           }
         ]

--- a/src/webpack/loaders/json.js
+++ b/src/webpack/loaders/json.js
@@ -7,7 +7,7 @@ export default {
       module: {
         loaders: [
           {
-            test: fileExtensions.JSON,
+            test: fileExtensions.pattern.JSON,
             loader: 'json-loader'
           }
         ]

--- a/src/webpack/loaders/style.js
+++ b/src/webpack/loaders/style.js
@@ -59,13 +59,13 @@ export default {
       module: {
         loaders: [
           {
-            test: fileExtensions.pattern.CSS,
+            test: fileExtensions.test.CSS,
             loader: shouldExtract
               ? extractCss.extract(cssLoaders)
               : ['style', ...cssLoaders].join('!')
           },
           {
-            test: fileExtensions.pattern.SCSS,
+            test: fileExtensions.test.SCSS,
             loader: shouldExtract
               ? extractSass.extract(sassLoaders)
               : ['style', ...sassLoaders].join('!')

--- a/src/webpack/loaders/style.js
+++ b/src/webpack/loaders/style.js
@@ -59,13 +59,13 @@ export default {
       module: {
         loaders: [
           {
-            test: fileExtensions.CSS,
+            test: fileExtensions.pattern.CSS,
             loader: shouldExtract
               ? extractCss.extract(cssLoaders)
               : ['style', ...cssLoaders].join('!')
           },
           {
-            test: fileExtensions.SCSS,
+            test: fileExtensions.pattern.SCSS,
             loader: shouldExtract
               ? extractSass.extract(sassLoaders)
               : ['style', ...sassLoaders].join('!')

--- a/src/webpack/loaders/video.js
+++ b/src/webpack/loaders/video.js
@@ -7,7 +7,7 @@ export default {
       module: {
         loaders: [
           {
-            test: fileExtensions.VIDEO,
+            test: fileExtensions.pattern.VIDEO,
             loader: 'file?name=[name]-[hash].[ext]'
           }
         ]

--- a/src/webpack/loaders/video.js
+++ b/src/webpack/loaders/video.js
@@ -7,7 +7,7 @@ export default {
       module: {
         loaders: [
           {
-            test: fileExtensions.pattern.VIDEO,
+            test: fileExtensions.test.VIDEO,
             loader: 'file?name=[name]-[hash].[ext]'
           }
         ]

--- a/src/webpack/loaders/yaml.js
+++ b/src/webpack/loaders/yaml.js
@@ -7,7 +7,7 @@ export default {
       module: {
         loaders: [
           {
-            test: fileExtensions.YAML,
+            test: fileExtensions.pattern.YAML,
             loader: 'json!yaml'
           }
         ]

--- a/src/webpack/loaders/yaml.js
+++ b/src/webpack/loaders/yaml.js
@@ -7,7 +7,7 @@ export default {
       module: {
         loaders: [
           {
-            test: fileExtensions.pattern.YAML,
+            test: fileExtensions.test.YAML,
             loader: 'json!yaml'
           }
         ]

--- a/src/webpack/presets/coverage.js
+++ b/src/webpack/presets/coverage.js
@@ -11,7 +11,7 @@ export default {
       module: {
         preLoaders: [
           {
-            test: (absPath) => absPath.match(fileExtensions.JAVASCRIPT) && !absPath.match(/\.spec/),
+            test: (absPath) => absPath.match(fileExtensions.pattern.JAVASCRIPT) && !absPath.match(/\.spec/),
             loader: 'isparta',
             exclude: /node_modules/
           }

--- a/src/webpack/presets/coverage.js
+++ b/src/webpack/presets/coverage.js
@@ -11,7 +11,7 @@ export default {
       module: {
         preLoaders: [
           {
-            test: (absPath) => absPath.match(fileExtensions.pattern.JAVASCRIPT) && !absPath.match(/\.spec/),
+            test: (absPath) => absPath.match(fileExtensions.test.JAVASCRIPT) && !absPath.match(/\.spec/),
             loader: 'isparta',
             exclude: /node_modules/
           }

--- a/src/webpack/presets/eslint.js
+++ b/src/webpack/presets/eslint.js
@@ -26,7 +26,7 @@ export default {
       module: {
         preLoaders: [
           {
-            test: fileExtensions.pattern.JAVASCRIPT,
+            test: fileExtensions.test.JAVASCRIPT,
             loader: 'eslint',
             exclude: /node_modules/
           }

--- a/src/webpack/presets/eslint.js
+++ b/src/webpack/presets/eslint.js
@@ -26,7 +26,7 @@ export default {
       module: {
         preLoaders: [
           {
-            test: fileExtensions.JAVASCRIPT,
+            test: fileExtensions.pattern.JAVASCRIPT,
             loader: 'eslint',
             exclude: /node_modules/
           }


### PR DESCRIPTION
We currently have all webpack loader file extension patterns in one place, which is great. However, we also have **lists** of file extensions spread out in different places. This pull request puts _all_ file extensions, be it lists or patterns, in one place and uses that as the single source of truth.