### PR TITLE
Improve performance of the development server 🏎

### DIFF
--- a/src/webpack/index.spec.js
+++ b/src/webpack/index.spec.js
@@ -39,7 +39,7 @@ describe('webpack', function () {
 
     it('should allow overwriting the default configuration', function () {
       const defaultConfig = webpack(baseSaguiConfig).webpack[0]
-      expect(defaultConfig.devtool).equal('source-map')
+      expect(defaultConfig.devtool).equal('cheap-module-eval-source-map')
 
       const saguiConfig = {
         ...baseSaguiConfig,

--- a/src/webpack/presets/base.js
+++ b/src/webpack/presets/base.js
@@ -1,15 +1,20 @@
 import { NoErrorsPlugin } from 'webpack'
 import path from 'path'
+import actions from '../../actions'
 
 export default {
   name: 'base',
-  configure ({ projectPath, saguiPath }) {
+  configure ({ action, projectPath, saguiPath }) {
     const projectSourcePath = path.join(projectPath, 'src')
+
+    // Use a much faster cheap-module-eval-source-map setup when possible
+    // see: http://webpack.github.io/docs/configuration.html#devtool
+    const devtool = action === actions.BUILD ? 'source-map' : 'cheap-module-eval-source-map'
 
     return {
       context: projectSourcePath,
 
-      devtool: 'source-map',
+      devtool,
 
       plugins: [new NoErrorsPlugin()],
 

--- a/src/webpack/presets/base.spec.js
+++ b/src/webpack/presets/base.spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai'
 import { join } from 'path'
 import { NoErrorsPlugin } from 'webpack'
 import preset from './base'
+import actions from '../../actions'
 
 const saguiPath = join(__dirname, '../../../../../')
 const projectPath = join(saguiPath, 'spec/fixtures/simple-project')
@@ -27,5 +28,17 @@ describe('base webpack preset', function () {
 
     const commons = config.plugins.filter((plugin) => plugin instanceof NoErrorsPlugin)
     expect(commons.length).equal(1)
+  })
+
+  describe('devtool', () => {
+    it('should setup the much faster cheap-module-eval-source-map by default', () => {
+      const config = preset.configure({ projectPath, saguiPath })
+      expect(config.devtool).equal('cheap-module-eval-source-map')
+    })
+
+    it('should output a separated source-map file when building', () => {
+      const config = preset.configure({ projectPath, saguiPath, action: actions.BUILD })
+      expect(config.devtool).equal('source-map')
+    })
   })
 })


### PR DESCRIPTION
Uses `cheap-module-eval-source-map` instead of `source-map` in every action but build.