### PR TITLE
Improve test runner performance by using null-loader on styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "karma-webpack": "^1.7.0",
     "lodash.uniq": "^4.3.0",
     "node-sass": "^3.3.3",
+    "null-loader": "^0.1.1",
     "parent-module": "^0.1.0",
     "phantomjs-prebuilt": "^2.1.4",
     "postcss-loader": "^0.9.1",

--- a/src/webpack/loaders/image.js
+++ b/src/webpack/loaders/image.js
@@ -1,14 +1,21 @@
 import fileExtensions from '../../file-extensions'
+import actions from '../../actions'
 
 export default {
   name: 'image',
-  configure () {
+  configure ({ action }) {
+    // User null-loader during tests
+    // for better performance
+    const loader = action === actions.TEST
+      ? 'null-loader'
+      : 'url-loader?limit=8192&name=[name]-[hash].[ext]'
+
     return {
       module: {
         loaders: [
           {
             test: fileExtensions.test.IMAGE,
-            loader: 'url-loader?limit=8192&name=[name]-[hash].[ext]'
+            loader
           }
         ]
       }

--- a/src/webpack/loaders/image.js
+++ b/src/webpack/loaders/image.js
@@ -1,21 +1,14 @@
 import fileExtensions from '../../file-extensions'
-import actions from '../../actions'
 
 export default {
   name: 'image',
   configure ({ action }) {
-    // User null-loader during tests
-    // for better performance
-    const loader = action === actions.TEST
-      ? 'null-loader'
-      : 'url-loader?limit=8192&name=[name]-[hash].[ext]'
-
     return {
       module: {
         loaders: [
           {
             test: fileExtensions.test.IMAGE,
-            loader
+            loader: 'url-loader?limit=8192&name=[name]-[hash].[ext]'
           }
         ]
       }

--- a/src/webpack/loaders/image.spec.js
+++ b/src/webpack/loaders/image.spec.js
@@ -1,0 +1,20 @@
+import { expect } from 'chai'
+import fileExtensions from '../../file-extensions'
+import actions from '../../actions'
+import loader from './image'
+
+describe('image', function () {
+  it('should be a url loader', function () {
+    const webpackConfig = loader.configure({})
+    const webpackLoader = webpackConfig.module.loaders[0]
+    expect(webpackLoader.test).eql(fileExtensions.test.IMAGE)
+    expect(webpackLoader.loader).eql('url-loader?limit=8192&name=[name]-[hash].[ext]')
+  })
+
+  it('should be a null loader while running the tests for better performance', () => {
+    const webpackConfig = loader.configure({ action: actions.TEST })
+    const webpackLoader = webpackConfig.module.loaders[0]
+    expect(webpackLoader.test).eql(fileExtensions.test.IMAGE)
+    expect(webpackLoader.loader).eql('null-loader')
+  })
+})

--- a/src/webpack/loaders/image.spec.js
+++ b/src/webpack/loaders/image.spec.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai'
 import fileExtensions from '../../file-extensions'
-import actions from '../../actions'
 import loader from './image'
 
 describe('image', function () {
@@ -9,12 +8,5 @@ describe('image', function () {
     const webpackLoader = webpackConfig.module.loaders[0]
     expect(webpackLoader.test).eql(fileExtensions.test.IMAGE)
     expect(webpackLoader.loader).eql('url-loader?limit=8192&name=[name]-[hash].[ext]')
-  })
-
-  it('should be a null loader while running the tests for better performance', () => {
-    const webpackConfig = loader.configure({ action: actions.TEST })
-    const webpackLoader = webpackConfig.module.loaders[0]
-    expect(webpackLoader.test).eql(fileExtensions.test.IMAGE)
-    expect(webpackLoader.loader).eql('null-loader')
   })
 })

--- a/src/webpack/loaders/style.js
+++ b/src/webpack/loaders/style.js
@@ -20,6 +20,25 @@ const defaultOptions = {
 export default {
   name: 'style',
   configure ({ action, optimize, pages = [], projectPath, style = {} }) {
+    // User null-loader during tests
+    // for better performance
+    if (action === actions.TEST) {
+      return {
+        module: {
+          loaders: [
+            {
+              test: fileExtensions.test.CSS,
+              loader: 'null-loader'
+            },
+            {
+              test: fileExtensions.test.SCSS,
+              loader: 'null-loader'
+            }
+          ]
+        }
+      }
+    }
+
     const options = {
       ...defaultOptions,
       ...style

--- a/src/webpack/loaders/style.spec.js
+++ b/src/webpack/loaders/style.spec.js
@@ -62,5 +62,14 @@ describe('style', function () {
       expect(config.module.loaders[1].loader.includes('extract-text-webpack-plugin')).to.eql(false)
     })
   })
+
+  describe('while running the tests', () => {
+    it('should be a null loader for better performance', () => {
+      const config = loader.configure({ action: actions.TEST })
+
+      expect(config.module.loaders[0].loader).to.eql('null-loader')
+      expect(config.module.loaders[1].loader).to.eql('null-loader')
+    })
+  })
 })
 


### PR DESCRIPTION
In a local project we saw a big bump in performance while running `npm run test:unit`.

With the style loader configured:

```bash
real  1m18.126s
user  1m9.155s
sys   0m10.080s
```

With the null-loader configured:

```bash
real  0m40.058s
user  0m35.967s
sys   0m2.225s
```