### PR TITLE
Enable Babel compact mode for speed! 🏎

### DIFF
--- a/src/webpack/loaders/javascript.js
+++ b/src/webpack/loaders/javascript.js
@@ -45,7 +45,12 @@ export default {
               path.join(projectPath, 'src'),
               ...userPaths
             ],
-            loader: 'babel'
+            loader: 'babel',
+            query: {
+              // speed up build time
+              // see: https://blog.mariusschulz.com/2016/07/12/speeding-up-babel-transpilation-with-compact-mode
+              compact: true
+            }
           }
         ]
       }

--- a/src/webpack/loaders/javascript.spec.js
+++ b/src/webpack/loaders/javascript.spec.js
@@ -32,6 +32,11 @@ describe('javaScript', () => {
     ])
   })
 
+  it('should enable compact mode (there is already source-maps and the performance is better)', () => {
+    const webpack = loader.configure({ projectPath })
+    expect(webpack.module.loaders[0].query).to.eql({ compact: true })
+  })
+
   it(`should resolve JavaScript files (${fileExtensions.list.JAVASCRIPT})`, function () {
     const webpack = loader.configure({ projectPath })
     expect(webpack.resolve.extensions).to.eql(fileExtensions.list.JAVASCRIPT)


### PR DESCRIPTION
Based on https://blog.mariusschulz.com/2016/07/12/speeding-up-babel-transpilation-with-compact-mode

In a local project we saw a bump from:

```
real  0m32.116s
user  0m31.874s
sys   0m1.955s
```

To:

```
real  0m30.964s
user  0m30.515s
sys   0m2.022s
```