### PR TITLE
Development environment should be easier on error handling

### DIFF
--- a/src/webpack/presets/base.js
+++ b/src/webpack/presets/base.js
@@ -16,7 +16,7 @@ export default {
 
       devtool,
 
-      plugins: watch ? [] : [new NoErrorsPlugin()],
+      plugins: watch || action === actions.DEVELOP ? [] : [new NoErrorsPlugin()],
 
       resolve: {
         extensions: [''],

--- a/src/webpack/presets/base.spec.js
+++ b/src/webpack/presets/base.spec.js
@@ -24,15 +24,22 @@ describe('base webpack preset', function () {
   })
 
   describe('NoErrorsPlugin', () => {
-    it('should prevent assets with erros from being emitted if not watching', function () {
-      const config = preset.configure({ projectPath, saguiPath })
+    it('should prevent assets with erros from being emitted if action is BUILD', function () {
+      const config = preset.configure({ projectPath, saguiPath, action: actions.BUILD })
 
       const commons = config.plugins.filter((plugin) => plugin instanceof NoErrorsPlugin)
       expect(commons.length).equal(1)
     })
 
-    it('should allow erros if watching', function () {
-      const config = preset.configure({ projectPath, saguiPath, watch: true })
+    it('should allow erros if watching while running action TEST', function () {
+      const config = preset.configure({ projectPath, saguiPath, action: actions.TEST, watch: true })
+
+      const commons = config.plugins.filter((plugin) => plugin instanceof NoErrorsPlugin)
+      expect(commons.length).equal(0)
+    })
+
+    it('should allow erros if action is DEVELOP', function () {
+      const config = preset.configure({ projectPath, saguiPath, action: actions.DEVELOP })
 
       const commons = config.plugins.filter((plugin) => plugin instanceof NoErrorsPlugin)
       expect(commons.length).equal(0)

--- a/src/webpack/presets/eslint.js
+++ b/src/webpack/presets/eslint.js
@@ -1,20 +1,12 @@
 import path from 'path'
 import fileExtensions from '../../file-extensions'
-import actions from '../../actions'
 
 export default {
   name: 'eslint',
   configure ({ watch, action, projectPath }) {
-    // we ignore debugger warning on any developer driven environment
-    // such as running the development server or any "watch" (such as test watch)
-    const ignoreDebugger = watch || action === actions.DEVELOP
-
     return {
       eslint: {
-        configFile: path.join(projectPath, '.eslintrc'),
-        rules: ignoreDebugger ? {
-          'no-debugger': 0 // 0 => "off"
-        } : {}
+        configFile: path.join(projectPath, '.eslintrc')
       },
 
       module: {

--- a/src/webpack/presets/eslint.spec.js
+++ b/src/webpack/presets/eslint.spec.js
@@ -1,32 +1,14 @@
 import { expect } from 'chai'
+import path from 'path'
 import preset from './eslint'
 import actions from '../../actions'
 
 describe('eslint webpack preset', function () {
-  describe('when watch is enabled', () => {
-    it('should set "no-debugger" rule to 0', function () {
-      const projectPath = 'a/demo/path'
-      const config = preset.configure({ watch: true, projectPath })
+  it('should point to a project eslintrc file', () => {
+    const projectPath = 'a/demo/path'
+    const action = actions.BUILD
+    const config = preset.configure({ action, projectPath })
 
-      expect(config.eslint.rules['no-debugger']).to.eql(0)
-    })
-  })
-  describe('when action is "develop"', () => {
-    it('should set "no-debugger" rule to 0', function () {
-      const projectPath = 'a/demo/path'
-      const action = actions.DEVELOP
-      const config = preset.configure({ action, projectPath })
-
-      expect(config.eslint.rules['no-debugger']).to.eql(0)
-    })
-  })
-  describe('when action is not "develop"', () => {
-    it('should not set any rules', () => {
-      const projectPath = 'a/demo/path'
-      const action = actions.BUILD
-      const config = preset.configure({ action, projectPath })
-
-      expect(config.eslint.rules).to.eql({})
-    })
+    expect(config.eslint.configFile).to.eql(path.join(projectPath, '.eslintrc'))
   })
 })


### PR DESCRIPTION
This allows more experimentation while developing a feature. Lint errors will not prevent the code from being executed!

But we still see the error in the terminal.