### PR TITLE
Add .npmignore template ⛔️

### DIFF
--- a/src/index.integration-spec.js
+++ b/src/index.integration-spec.js
@@ -46,6 +46,10 @@ describe('[integration] sagui', function () {
       return sagui({ projectPath, action: actions.LINT }).run()
     })
 
+    it('should have an .npmignore file', () => {
+      fs.readFileSync(path.join(projectPath, '.npmignore'))
+    })
+
     describe('once we add content', () => {
       beforeEach(function () {
         fs.copySync(projectContent, projectSrcPath, { clobber: true })

--- a/src/runner/install/template.js
+++ b/src/runner/install/template.js
@@ -32,6 +32,7 @@ function copyDotFiles (projectPath) {
   safeCopy(join(dotFilesPath, 'eslintrc'), join(projectPath, '.eslintrc'))
   safeCopy(join(dotFilesPath, 'eslintignore'), join(projectPath, '.eslintignore'))
   safeCopy(join(dotFilesPath, 'gitignore'), join(projectPath, '.gitignore'))
+  safeCopy(join(dotFilesPath, 'npmignore'), join(projectPath, '.npmignore'))
 }
 
 function safeCopy (source, destination) {

--- a/template/dot-files/npmignore
+++ b/template/dot-files/npmignore
@@ -1,0 +1,8 @@
+.babelrc
+.editorconfig
+.eslintignore
+.eslintrc
+coverage
+node_modules
+npm-debug.log
+src


### PR DESCRIPTION
When publishing libraries built with Sagui to npm, we don't want the whole setup to be sent. Specifically, the `.babelrc` file needs to be ignored because otherwise it will be picked up by babel compilers working on consumer projects.