### PR TITLE
Run tests with any extension

### DIFF
--- a/karma-static-files/test-bundle.js
+++ b/karma-static-files/test-bundle.js
@@ -1,2 +1,2 @@
-const testsContext = require.context('../../../src', true, /\.spec\.js$/)
+const testsContext = require.context('../../../src', true, /\.spec\..+$/)
 testsContext.keys().forEach(testsContext)

--- a/karma-static-files/test-bundle.js
+++ b/karma-static-files/test-bundle.js
@@ -1,2 +1,6 @@
+/**
+ * Sagui test bundler that finds all test files in a project
+ * for Karma to run them.
+ */
 const testsContext = require.context('../../../src', true, /\.spec\..+$/)
 testsContext.keys().forEach(testsContext)


### PR DESCRIPTION
The recent (unreleased) change in how we find the test files was excluding `jsx` or `es6` files for example.