### PR TITLE
Exit with status `1` on error 💀

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -18,6 +18,7 @@ export default (argv = []) => {
 
     logError('Error starting up')
     logError(e.stack || e)
+    process.exit(1)
   }
 
   if (!argv.slice(2).length) program.outputHelp()


### PR DESCRIPTION
Very simple mistake... we were handling the exceptions but not exiting the process with an error.

Fixes #190 