### PR TITLE
Put the flowtype interfaces into the main repo

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ template
 lib
 tmp
 fixtures
+flowtype-interfaces

--- a/flowtype-interfaces/jasmine.js
+++ b/flowtype-interfaces/jasmine.js
@@ -1,0 +1,17 @@
+// Simplified Jasmine type definitions, taken from
+// https://github.com/flowtype/flow-typed/blob/master/definitions/npm/jasmine_v2.4.x/flow_all/jasmine_v2.4.x.js#L21
+declare function describe(): any;
+declare function fdescribe(): any;
+declare function xdescribe(): any;
+
+declare function beforeEach(): any;
+declare function afterEach(): any;
+declare function beforeAll(): any;
+declare function afterAll(): any;
+
+declare function it(): any;
+declare function fit(): any;
+declare function xit(): any;
+
+declare function expect(): any;
+declare function spyOn(): any;

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "flow-bin": "0.32.0",
-    "flowtype-interfaces-sagui": "0.1.0",
     "fs-extra": "^0.30.0",
     "html-webpack-plugin": "^2.7.2",
     "jasmine-core": "^2.5.1",

--- a/template/dot-files/flowconfig
+++ b/template/dot-files/flowconfig
@@ -6,7 +6,7 @@
 [include]
 
 [libs]
-node_modules/flowtype-interfaces-sagui/interfaces/
+node_modules/sagui/flowtype-interfaces/
 
 [options]
 module.system=haste


### PR DESCRIPTION
The current package https://github.com/saguijs/flowtype-interfaces-sagui is unnecessary since the configuration can be bundled directly in the main Sagui package. Also, Sinon interfaces got removed since Sinon is removed for v7.