### PR TITLE
Add support for object configuration of library to have UMD target

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,21 @@ import leftPad from 'left-pad'
 
 When building the project, `react` won't actually be bundled in the output but `left-pad` will, so your project won't blow up once `left-pad` is unpublished again.
 
+#### Publishing libraries as UMD
+
+If you need to build your library targeting UMD, you can use a slightly different configuration. For UMD you need to provide a _name_ for the library, which is going to be the name that it will use to add itself to the `window` object when loaded as a global in the browser.
+
+```js
+module.exports = {
+  libraries: [
+    {
+      main: 'button',
+      name: 'MyUIButton'
+    }
+  ]
+}
+```
+
 ### `style.cssModules`
 
 By default, styles compiled with Sagui will be output as [CSS Modules](https://github.com/css-modules), meaning they won't be global.

--- a/README.md
+++ b/README.md
@@ -194,14 +194,14 @@ When building the project, `react` won't actually be bundled in the output but `
 
 #### Publishing libraries as UMD
 
-If you need to build your library targeting UMD, you can use a slightly different configuration. For UMD you need to provide a _name_ for the library, which is going to be the name that it will use to add itself to the `window` object when loaded as a global in the browser.
+If you need to build your library targeting UMD, you can use a slightly different configuration. For UMD you need to provide a _umdName_ for the library, which is going to be the name that it will use to add itself to the `window` object when loaded as a global in the browser.
 
 ```js
 module.exports = {
   libraries: [
     {
       main: 'button',
-      name: 'MyUIButton'
+      umdName: 'MyUIButton'
     }
   ]
 }

--- a/src/webpack/archetypes/library.js
+++ b/src/webpack/archetypes/library.js
@@ -19,27 +19,21 @@ export default {
 
     const externals = probeExternals(projectPath)
 
-    if (typeof library === 'string') {
-      return {
-        entry: `./${library}.js`,
-        output: {
-          path: join(projectPath, 'dist'),
-          filename: `${library}.js`,
-          libraryTarget: action === actions.TEST ? undefined : 'commonjs2'
-        },
-        externals: action === actions.TEST ? [] : externals
-      }
-    } else {
-      return {
-        entry: `./${library.main}.js`,
-        output: {
-          path: join(projectPath, 'dist'),
-          filename: `${library.main}.js`,
-          libraryTarget: 'umd',
-          umdNamedDefine: library.name
-        },
-        externals: action === actions.TEST ? [] : externals
-      }
+    const libraryConfig = typeof library === 'string'
+      ? { main: library }
+      : library
+
+    const target = libraryConfig.umdName ? 'umd' : 'commonjs2'
+
+    return {
+      entry: `./${libraryConfig.main}.js`,
+      output: {
+        path: join(projectPath, 'dist'),
+        filename: `${libraryConfig.main}.js`,
+        libraryTarget: action === actions.TEST ? undefined : target,
+        umdNamedDefine: libraryConfig.umdName
+      },
+      externals: action === actions.TEST ? [] : externals
     }
   }
 }

--- a/src/webpack/archetypes/library.js
+++ b/src/webpack/archetypes/library.js
@@ -19,14 +19,27 @@ export default {
 
     const externals = probeExternals(projectPath)
 
-    return {
-      entry: `./${library}.js`,
-      output: {
-        path: join(projectPath, 'dist'),
-        filename: `${library}.js`,
-        libraryTarget: action === actions.TEST ? undefined : 'commonjs2'
-      },
-      externals: action === actions.TEST ? [] : externals
+    if (typeof library === 'string') {
+      return {
+        entry: `./${library}.js`,
+        output: {
+          path: join(projectPath, 'dist'),
+          filename: `${library}.js`,
+          libraryTarget: action === actions.TEST ? undefined : 'commonjs2'
+        },
+        externals: action === actions.TEST ? [] : externals
+      }
+    } else {
+      return {
+        entry: `./${library.main}.js`,
+        output: {
+          path: join(projectPath, 'dist'),
+          filename: `${library.main}.js`,
+          libraryTarget: 'umd',
+          umdNamedDefine: library.name
+        },
+        externals: action === actions.TEST ? [] : externals
+      }
     }
   }
 }

--- a/src/webpack/archetypes/library.spec.js
+++ b/src/webpack/archetypes/library.spec.js
@@ -56,4 +56,61 @@ describe('library webpack preset', function () {
       })
     })
   })
+
+  describe('object configuration', function () {
+    const baseConfiguration = {
+      library: {
+        main: 'index',
+        name: 'Library'
+      },
+      projectPath
+    }
+
+    it('should have a single entry pointing to index.js', function () {
+      const webpackConfig = preset.configure(baseConfiguration)
+      expect(webpackConfig.entry).eql('./index.js')
+    })
+
+    it('should have the default exporting target of umd', function () {
+      const webpackConfig = preset.configure(baseConfiguration)
+      expect(webpackConfig.output.libraryTarget).eql('umd')
+    })
+
+    it('should set the exporting target even if the action is test (since it\'s UMD)', function () {
+      const webpackConfig = preset.configure({ ...baseConfiguration, action: actions.TEST })
+      expect(webpackConfig.output.libraryTarget).eql('umd')
+    })
+
+    it('should have the umdNamedDefine be Library as specified', function () {
+      const webpackConfig = preset.configure(baseConfiguration)
+      expect(webpackConfig.output.umdNamedDefine).eql('Library')
+    })
+
+    it('should have the filename as index.js', function () {
+      const webpackConfig = preset.configure(baseConfiguration)
+      expect(webpackConfig.output.filename).eql('index.js')
+    })
+
+    it('should have the output path configured as the build folder', function () {
+      const webpackConfig = preset.configure(baseConfiguration)
+      expect(webpackConfig.output.path).eql(join(projectPath, 'dist'))
+    })
+
+    describe('externals', function () {
+      it('should infer the externals based on the packgage.json peerDependencies', function () {
+        const webpackConfig = preset.configure(baseConfiguration)
+        expect(webpackConfig.externals).eql(['react', 'react-dom'])
+      })
+
+      it('should have an empty externals if the action is test', function () {
+        const webpackConfig = preset.configure({ ...baseConfiguration, action: actions.TEST })
+        expect(webpackConfig.externals).eql([])
+      })
+
+      it('should have an empty externals if the packgage.json does not have a peerDependencies', function () {
+        const webpackConfig = preset.configure({ ...baseConfiguration, projectPath: projectWithoutPeerDependenciesPath })
+        expect(webpackConfig.externals).eql([])
+      })
+    })
+  })
 })

--- a/src/webpack/archetypes/library.spec.js
+++ b/src/webpack/archetypes/library.spec.js
@@ -8,109 +8,70 @@ const projectPath = join(saguiPath, 'spec/fixtures/library-project')
 const projectWithoutPeerDependenciesPath = join(saguiPath, 'spec/fixtures/library-project-without-peer-dependencies')
 
 describe('library webpack preset', function () {
-  describe('simple name configuration', function () {
-    const baseConfiguration = {
-      library: 'index',
-      projectPath
-    }
+  const baseConfiguration = {
+    library: 'index',
+    projectPath
+  }
 
-    it('should have a single entry pointing to index.js', function () {
+  it('should have a single entry pointing to index.js', function () {
+    const webpackConfig = preset.configure(baseConfiguration)
+    expect(webpackConfig.entry).eql('./index.js')
+  })
+
+  it('should have the default exporting target of commonjs2 (module.exports = xxx)', function () {
+    const webpackConfig = preset.configure(baseConfiguration)
+    expect(webpackConfig.output.libraryTarget).eql('commonjs2')
+  })
+
+  it('should NOT SET the exporting target if action is test (a browser wont understand commonjs modules)', function () {
+    const webpackConfig = preset.configure({ ...baseConfiguration, action: actions.TEST })
+    expect(webpackConfig.output.libraryTarget).undefined
+  })
+
+  it('should have the filename as index.js', function () {
+    const webpackConfig = preset.configure(baseConfiguration)
+    expect(webpackConfig.output.filename).eql('index.js')
+  })
+
+  it('should have the output path configured as the build folder', function () {
+    const webpackConfig = preset.configure(baseConfiguration)
+    expect(webpackConfig.output.path).eql(join(projectPath, 'dist'))
+  })
+
+  describe('externals', function () {
+    it('should infer the externals based on the packgage.json peerDependencies', function () {
       const webpackConfig = preset.configure(baseConfiguration)
-      expect(webpackConfig.entry).eql('./index.js')
+      expect(webpackConfig.externals).eql(['react', 'react-dom'])
     })
 
-    it('should have the default exporting target of commonjs2 (module.exports = xxx)', function () {
-      const webpackConfig = preset.configure(baseConfiguration)
-      expect(webpackConfig.output.libraryTarget).eql('commonjs2')
-    })
-
-    it('should NOT SET the exporting target if action is test (a browser wont understand commonjs modules)', function () {
+    it('should have an empty externals if the action is test', function () {
       const webpackConfig = preset.configure({ ...baseConfiguration, action: actions.TEST })
-      expect(webpackConfig.output.libraryTarget).undefined
+      expect(webpackConfig.externals).eql([])
     })
 
-    it('should have the filename as index.js', function () {
-      const webpackConfig = preset.configure(baseConfiguration)
-      expect(webpackConfig.output.filename).eql('index.js')
-    })
-
-    it('should have the output path configured as the build folder', function () {
-      const webpackConfig = preset.configure(baseConfiguration)
-      expect(webpackConfig.output.path).eql(join(projectPath, 'dist'))
-    })
-
-    describe('externals', function () {
-      it('should infer the externals based on the packgage.json peerDependencies', function () {
-        const webpackConfig = preset.configure(baseConfiguration)
-        expect(webpackConfig.externals).eql(['react', 'react-dom'])
-      })
-
-      it('should have an empty externals if the action is test', function () {
-        const webpackConfig = preset.configure({ ...baseConfiguration, action: actions.TEST })
-        expect(webpackConfig.externals).eql([])
-      })
-
-      it('should have an empty externals if the packgage.json does not have a peerDependencies', function () {
-        const webpackConfig = preset.configure({ ...baseConfiguration, projectPath: projectWithoutPeerDependenciesPath })
-        expect(webpackConfig.externals).eql([])
-      })
+    it('should have an empty externals if the packgage.json does not have a peerDependencies', function () {
+      const webpackConfig = preset.configure({ ...baseConfiguration, projectPath: projectWithoutPeerDependenciesPath })
+      expect(webpackConfig.externals).eql([])
     })
   })
 
-  describe('object configuration', function () {
+  describe('umd configuration', function () {
     const baseConfiguration = {
       library: {
         main: 'index',
-        name: 'Library'
+        umdName: 'Library'
       },
       projectPath
     }
-
-    it('should have a single entry pointing to index.js', function () {
-      const webpackConfig = preset.configure(baseConfiguration)
-      expect(webpackConfig.entry).eql('./index.js')
-    })
 
     it('should have the default exporting target of umd', function () {
       const webpackConfig = preset.configure(baseConfiguration)
       expect(webpackConfig.output.libraryTarget).eql('umd')
     })
 
-    it('should set the exporting target even if the action is test (since it\'s UMD)', function () {
-      const webpackConfig = preset.configure({ ...baseConfiguration, action: actions.TEST })
-      expect(webpackConfig.output.libraryTarget).eql('umd')
-    })
-
     it('should have the umdNamedDefine be Library as specified', function () {
       const webpackConfig = preset.configure(baseConfiguration)
       expect(webpackConfig.output.umdNamedDefine).eql('Library')
-    })
-
-    it('should have the filename as index.js', function () {
-      const webpackConfig = preset.configure(baseConfiguration)
-      expect(webpackConfig.output.filename).eql('index.js')
-    })
-
-    it('should have the output path configured as the build folder', function () {
-      const webpackConfig = preset.configure(baseConfiguration)
-      expect(webpackConfig.output.path).eql(join(projectPath, 'dist'))
-    })
-
-    describe('externals', function () {
-      it('should infer the externals based on the packgage.json peerDependencies', function () {
-        const webpackConfig = preset.configure(baseConfiguration)
-        expect(webpackConfig.externals).eql(['react', 'react-dom'])
-      })
-
-      it('should have an empty externals if the action is test', function () {
-        const webpackConfig = preset.configure({ ...baseConfiguration, action: actions.TEST })
-        expect(webpackConfig.externals).eql([])
-      })
-
-      it('should have an empty externals if the packgage.json does not have a peerDependencies', function () {
-        const webpackConfig = preset.configure({ ...baseConfiguration, projectPath: projectWithoutPeerDependenciesPath })
-        expect(webpackConfig.externals).eql([])
-      })
     })
   })
 })


### PR DESCRIPTION
Configuration would look like this:

```js
module.exports = {
  libraries: [
    {
      main: 'button',
      name: 'MyUIButton'
    }
  ]
}
```

Ping @farfalena