### PR TITLE
Fix source-maps in development 😭

### DIFF
--- a/src/webpack/index.spec.js
+++ b/src/webpack/index.spec.js
@@ -39,7 +39,7 @@ describe('webpack', function () {
 
     it('should allow overwriting the default configuration', function () {
       const defaultConfig = webpack(baseSaguiConfig).webpack[0]
-      expect(defaultConfig.devtool).equal('cheap-module-eval-source-map')
+      expect(defaultConfig.devtool).equal('inline-source-map')
 
       const saguiConfig = {
         ...baseSaguiConfig,

--- a/src/webpack/presets/base.js
+++ b/src/webpack/presets/base.js
@@ -14,12 +14,7 @@ const devtool = (action) => {
     return 'source-map'
   }
 
-  if (action === actions.TEST) {
-    return 'inline-source-map'
-  }
-
-  // Use a much faster cheap-module-eval-source-map setup when possible
-  return 'cheap-module-eval-source-map'
+  return 'inline-source-map'
 }
 
 export default {

--- a/src/webpack/presets/base.spec.js
+++ b/src/webpack/presets/base.spec.js
@@ -47,19 +47,14 @@ describe('base webpack preset', function () {
   })
 
   describe('devtool', () => {
-    it('should setup the much faster cheap-module-eval-source-map by default', () => {
+    it('should setup the inline-source-map by default', () => {
       const config = preset.configure({ projectPath, saguiPath })
-      expect(config.devtool).equal('cheap-module-eval-source-map')
+      expect(config.devtool).equal('inline-source-map')
     })
 
     it('should output a separated source-map file when building', () => {
       const config = preset.configure({ projectPath, saguiPath, action: actions.BUILD })
       expect(config.devtool).equal('source-map')
-    })
-
-    it('should inline the source-map while testing', () => {
-      const config = preset.configure({ projectPath, saguiPath, action: actions.TEST })
-      expect(config.devtool).equal('inline-source-map')
     })
   })
 })


### PR DESCRIPTION
The previously working solution is no longer functional in Chrome.

Switch to the alternative `inline-source-map` instead as recommended by https://github.com/mxstbr/react-boilerplate/issues/1112#issuecomment-254797102