### PR TITLE
Run Babel builds in parallel 🏃

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 lib
 tmp
 npm-debug.log
+.sagui

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "file-loader": "^0.9.0",
     "flow-bin": "0.32.0",
     "fs-extra": "^0.30.0",
+    "happypack": "^3.0.2",
     "html-webpack-plugin": "^2.7.2",
     "jasmine-core": "^2.5.1",
     "json-loader": "^0.5.4",

--- a/src/runner/install/template.js
+++ b/src/runner/install/template.js
@@ -27,7 +27,6 @@ function copyBase (projectPath) {
 }
 
 function copyDotFiles (projectPath) {
-  safeCopy(join(dotFilesPath, 'babelrc'), join(projectPath, '.babelrc'))
   safeCopy(join(dotFilesPath, 'editorconfig'), join(projectPath, '.editorconfig'))
   safeCopy(join(dotFilesPath, 'eslintignore'), join(projectPath, '.eslintignore'))
   safeCopy(join(dotFilesPath, 'eslintrc'), join(projectPath, '.eslintrc'))

--- a/src/webpack/loaders/javascript.spec.js
+++ b/src/webpack/loaders/javascript.spec.js
@@ -35,7 +35,7 @@ describe('javaScript', () => {
 
   it('should disable compact mode (enabling it breaks source maps)', () => {
     const webpack = loader.configure({ projectPath })
-    expect(webpack.module.loaders[0].query).to.eql({ compact: false })
+    expect(getBabelLoaderQuery(webpack).compact).to.eql(false)
   })
 
   it(`should resolve JavaScript files (${fileExtensions.list.JAVASCRIPT})`, function () {
@@ -45,18 +45,20 @@ describe('javaScript', () => {
 
   it('should not setup any babel plugin by default', () => {
     const webpack = loader.configure({ projectPath })
-    expect(webpack.babel.plugins).to.eql([])
+    expect(getBabelLoaderQuery(webpack).plugins).to.eql([])
   })
 
-  it('should not setup any webpack plugin by default', () => {
+  it('should not setup any HMR plugin by default', () => {
     const webpack = loader.configure({ projectPath })
-    expect(webpack.plugins).to.eql([])
+
+    const plugins = webpack.plugins.filter((plugin) => plugin instanceof HotModuleReplacementPlugin)
+    expect(plugins.length).equal(0)
   })
 
   describe('HMR', () => {
     it('should setup react transform babel plugin if action is develop', () => {
       const webpack = loader.configure({ projectPath, action: actions.DEVELOP })
-      expect(webpack.babel.plugins[0][0]).to.equal(reactTransform)
+      expect(getBabelLoaderQuery(webpack).plugins[0][0]).to.equal(reactTransform)
     })
 
     it('should setup the HotModuleReplacementPlugin if action is develop', () => {
@@ -70,8 +72,9 @@ describe('javaScript', () => {
   describe('code coverage instrumentation', () => {
     it('should setup istanbul babel plugin ignoring test files if action is test and coverage is enabled', () => {
       const webpack = loader.configure({ projectPath, action: actions.TEST_UNIT, coverage: true })
-      expect(webpack.babel.plugins[0][0]).to.equal(istanbul)
-      expect(webpack.babel.plugins[0][1]).to.eql({
+
+      expect(getBabelLoaderQuery(webpack).plugins[0][0]).to.equal(istanbul)
+      expect(getBabelLoaderQuery(webpack).plugins[0][1]).to.eql({
         exclude: [
           '**/*.spec.*',
           '**/node_modules/**/*'
@@ -81,7 +84,11 @@ describe('javaScript', () => {
 
     it('should NOT setup istanbul babel plugin if action is test and coverage is disabled', () => {
       const webpack = loader.configure({ projectPath, action: actions.TEST_UNIT })
-      expect(webpack.plugins).to.eql([])
+      expect(getBabelLoaderQuery(webpack).plugins).to.eql([])
     })
   })
 })
+
+const getBabelLoaderQuery = (config) => config.plugins
+  .find((plugin) => plugin.name === 'HappyPack')
+  .config.loaders[0].query

--- a/template/dot-files/babelrc
+++ b/template/dot-files/babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["sagui"]
-}

--- a/template/dot-files/gitignore
+++ b/template/dot-files/gitignore
@@ -3,3 +3,4 @@ node_modules
 npm-debug.log
 dist
 .DS_Store
+.sagui


### PR DESCRIPTION
Setups HappyPack, a Webpack plugin to run builds in parallel.

This PR also removes support for custom `.babelrc` files, since it would make it complicated to support user configurations and overwrites. We know of a couple of projects that actually disable them.

Closes #211 