### PR TITLE
Add missing flowtype interfaces to the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     ".eslintrc",
     "bin",
     "karma-static-files",
+    "flowtype-interfaces",
     "lib",
     "src",
     "template"


### PR DESCRIPTION
This is causing flowtype check to always fail on tests.