### PR TITLE
Explicitly specify eslint-loader in webpack presets (Fixes #306)

### DIFF
--- a/src/webpack/presets/eslint.js
+++ b/src/webpack/presets/eslint.js
@@ -13,7 +13,7 @@ export default {
         preLoaders: [
           {
             test: fileExtensions.test.JAVASCRIPT,
-            loader: 'eslint',
+            loader: 'eslint-loader',
             exclude: /node_modules/
           }
         ]


### PR DESCRIPTION
If a developer needs to install eslint locally in their sagui-based project, this change will safeguard them from experiencing the bug outlined in #306 