### PR TITLE
Use headless Chrome instead of PhantomJS to run tests 🤖

### DIFF
--- a/src/configure-karma/index.js
+++ b/src/configure-karma/index.js
@@ -19,7 +19,15 @@ const buildStandardKarmaConfig = (saguiConfig, webpackConfig) => {
 
     basePath: projectPath,
 
-    browsers: ['PhantomJS'],
+    browsers: ['Chrome_headless'],
+
+    // you can define custom flags
+    customLaunchers: {
+      Chrome_headless: {
+        base: 'ChromeCanary',
+        flags: ['--headless', '--remote-debugging-port=9222', 'http://0.0.0.0:9876/']
+      }
+    },
 
     reporters: [
       'mocha',

--- a/src/configure-karma/index.spec.js
+++ b/src/configure-karma/index.spec.js
@@ -20,7 +20,7 @@ describe('karma', function () {
 
   describe('extension', function () {
     it('should allow overwriting the default configuration', function () {
-      expect(karma(baseSaguiConfig, webpackConfig).browsers).eql(['PhantomJS'])
+      expect(karma(baseSaguiConfig, webpackConfig).browsers).eql(['Chrome_headless'])
       expect(karma({ ...baseSaguiConfig, additionalKarmaConfig: { browsers: ['Chrome'] } }, webpackConfig).browsers).eql(['Chrome'])
     })
   })


### PR DESCRIPTION
We have a couple of options going forward:
- Always ship with the default PhantomJS support but use Chrome if it is available;
- Completely ditch PhantomJS, and make Chrome another global dependency of Sagui.

However, it is currently only available in the Canary release.

More info https://www.chromestatus.com/features/5678767817097216