### PR TITLE
Drop unused style loader features and fix issues on CSS Modules and autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "postcss-modules-values": "^1.2.2",
     "raw-loader": "^0.5.1",
     "react-transform-hmr": "^1.0.4",
-    "resolve-url-loader": "^2.0.2",
     "sass-loader": "^6.0.3",
     "standard": "^10.0.1",
     "standard-loader": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "parent-module": "^0.1.0",
     "phantomjs-prebuilt": "^2.1.14",
     "postcss-loader": "^1.3.3",
-    "postcss-modules-values": "^1.2.2",
     "raw-loader": "^0.5.1",
     "react-transform-hmr": "^1.0.4",
     "sass-loader": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-register": "^6.24.0",
     "chai": "^3.5.0",
     "in-publish": "^2.0.0",
+    "jsdom": "^9.12.0",
     "mocha": "^3.2.0",
     "snazzy": "^7.0.0",
     "temp": "^0.8.3",

--- a/spec/fixtures/index.html
+++ b/spec/fixtures/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Testing</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/spec/fixtures/project-with-css-modules/sagui.config.js
+++ b/spec/fixtures/project-with-css-modules/sagui.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  libraries: ['index']
+}

--- a/spec/fixtures/project-with-css-modules/src/component-a/index.js
+++ b/spec/fixtures/project-with-css-modules/src/component-a/index.js
@@ -1,0 +1,3 @@
+import style from './index.scss'
+
+export default style.content

--- a/spec/fixtures/project-with-css-modules/src/component-a/index.scss
+++ b/spec/fixtures/project-with-css-modules/src/component-a/index.scss
@@ -1,0 +1,3 @@
+.content {
+  background: yellow;
+}

--- a/spec/fixtures/project-with-css-modules/src/component-a/index.scss
+++ b/spec/fixtures/project-with-css-modules/src/component-a/index.scss
@@ -1,3 +1,4 @@
 .content {
   background: yellow;
+  flex: auto;
 }

--- a/spec/fixtures/project-with-css-modules/src/component-b/index.js
+++ b/spec/fixtures/project-with-css-modules/src/component-b/index.js
@@ -1,0 +1,3 @@
+import style from './index.scss'
+
+export default style.content

--- a/spec/fixtures/project-with-css-modules/src/component-b/index.scss
+++ b/spec/fixtures/project-with-css-modules/src/component-b/index.scss
@@ -1,0 +1,3 @@
+.content {
+  background: red;
+}

--- a/spec/fixtures/project-with-css-modules/src/index.js
+++ b/spec/fixtures/project-with-css-modules/src/index.js
@@ -1,0 +1,7 @@
+import componentA from './component-a'
+import componentB from './component-b'
+
+export default {
+  componentA,
+  componentB
+}

--- a/spec/integration/index.integration-spec.js
+++ b/spec/integration/index.integration-spec.js
@@ -111,7 +111,7 @@ describe('[integration] sagui', function () {
       })
     })
 
-    describe('project with CSS Modules', () => {
+    describe('style loader', () => {
       const projectWithCSSModules = path.join(__dirname, '../fixtures/project-with-css-modules')
       const htmlFile = path.join(__dirname, '../fixtures/index.html')
 
@@ -131,7 +131,7 @@ describe('[integration] sagui', function () {
         delete global.document
       })
 
-      it('should build with the unique keys', () => {
+      it('should build with the unique CSS Modules keys', () => {
         return sagui({ projectPath, action: actions.BUILD }).then(() => {
           const dist = require(path.join(projectPath, '/dist/index')).default
 

--- a/spec/integration/index.integration-spec.js
+++ b/spec/integration/index.integration-spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import fs from 'fs-extra'
 import path from 'path'
+import jsdom from 'jsdom'
 import sagui, { InvalidSaguiConfig } from '../../src'
 import actions from '../../src/actions'
 import temp from 'temp'
@@ -107,6 +108,37 @@ describe('[integration] sagui', function () {
             () => new Error('It should have failed'),
             (error) => expect(error).instanceof(InvalidSaguiConfig)
           )
+      })
+    })
+
+    describe('project with CSS Modules', () => {
+      const projectWithCSSModules = path.join(__dirname, '../fixtures/project-with-css-modules')
+      const htmlFile = path.join(__dirname, '../fixtures/index.html')
+
+      beforeEach((done) => {
+        fs.copySync(projectWithCSSModules, projectPath, { overwrite: true })
+
+        jsdom.env(htmlFile, (err, window) => {
+          global.window = window
+          global.document = window.document
+          done()
+        });
+      })
+
+      afterEach(() => {
+        global.window.close()
+        delete global.window
+        delete global.document
+      })
+
+      it('should build with the unique keys', () => {
+        return sagui({ projectPath, action: actions.BUILD }).then(() => {
+          const dist = require(path.join(projectPath, '/dist/index')).default
+
+          expect(dist.componentA).to.match(/content-.{5}/)
+          expect(dist.componentB).to.match(/content-.{5}/)
+          expect(dist.componentA).not.to.eql(dist.componentB)
+        })
       })
     })
 

--- a/spec/integration/index.integration-spec.js
+++ b/spec/integration/index.integration-spec.js
@@ -145,8 +145,8 @@ describe('[integration] sagui', function () {
         return sagui({ projectPath, action: actions.BUILD, optimize: true }).then(() => {
           const dist = require(path.join(projectPath, '/dist/index')).default
 
-          expect(dist.componentA).to.match(/_.{5}/)
-          expect(dist.componentB).to.match(/_.{5}/)
+          expect(dist.componentA).to.match(/^.{5,6}$/)
+          expect(dist.componentB).to.match(/^.{5,6}$/)
           expect(dist.componentA).not.to.eql(dist.componentB)
         })
       })

--- a/spec/integration/index.integration-spec.js
+++ b/spec/integration/index.integration-spec.js
@@ -141,6 +141,16 @@ describe('[integration] sagui', function () {
         })
       })
 
+      it('should build (optimized) with the unique CSS Modules keys', () => {
+        return sagui({ projectPath, action: actions.BUILD, optimize: true }).then(() => {
+          const dist = require(path.join(projectPath, '/dist/index')).default
+
+          expect(dist.componentA).to.match(/_.{5}/)
+          expect(dist.componentB).to.match(/_.{5}/)
+          expect(dist.componentA).not.to.eql(dist.componentB)
+        })
+      })
+
       it('should autoprefix CSS rules', () => {
         return sagui({ projectPath, action: actions.BUILD }).then(() => {
           const dist = fs.readFileSync(path.join(projectPath, '/dist/index.js'))

--- a/spec/integration/index.integration-spec.js
+++ b/spec/integration/index.integration-spec.js
@@ -140,6 +140,14 @@ describe('[integration] sagui', function () {
           expect(dist.componentA).not.to.eql(dist.componentB)
         })
       })
+
+      it('should autoprefix CSS rules', () => {
+        return sagui({ projectPath, action: actions.BUILD }).then(() => {
+          const dist = fs.readFileSync(path.join(projectPath, '/dist/index.js'))
+
+          expect(dist).to.match(/-ms-flex/)
+        })
+      })
     })
 
     describe('once we add content with lint errors', () => {

--- a/src/configure-webpack/index.js
+++ b/src/configure-webpack/index.js
@@ -82,6 +82,15 @@ const buildSharedWebpackConfig = (saguiConfig) => {
 
       new DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+      }),
+
+      // Fixes an issue with colliding CSS Modules
+      // There is an integration test to validate it
+      // see:
+      //  - https://github.com/saguijs/sagui/issues/338
+      //  - https://github.com/webpack-contrib/css-loader/issues/413#issuecomment-283944881
+      new webpack.LoaderOptionsPlugin({
+        context: projectSourcePath,
       })
     ],
 

--- a/src/configure-webpack/index.js
+++ b/src/configure-webpack/index.js
@@ -82,15 +82,6 @@ const buildSharedWebpackConfig = (saguiConfig) => {
 
       new DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
-      }),
-
-      // Fixes an issue with colliding CSS Modules
-      // There is an integration test to validate it
-      // see:
-      //  - https://github.com/saguijs/sagui/issues/338
-      //  - https://github.com/webpack-contrib/css-loader/issues/413#issuecomment-283944881
-      new webpack.LoaderOptionsPlugin({
-        context: projectSourcePath,
       })
     ],
 

--- a/src/configure-webpack/loaders/style.js
+++ b/src/configure-webpack/loaders/style.js
@@ -65,9 +65,8 @@ export default {
     // importLoaders: use the following sass-loader in @import statements
     // modules: enable css-modules
     const sassLoaders = [
-      `css-loader?${cssModules}&${sourceMaps}&importLoaders=3&localIdentName=${localIdentName}`,
+      `css-loader?${cssModules}&${sourceMaps}&importLoaders=2&localIdentName=${localIdentName}`,
       'postcss-loader',
-      'resolve-url-loader', // Fixes loading of relative URLs in nested Sass modules
       `sass-loader?${sourceMaps}&outputStyle=expanded&` +
         'includePaths[]=' + (path.resolve(projectPath, './node_modules'))
     ]

--- a/src/configure-webpack/loaders/style.js
+++ b/src/configure-webpack/loaders/style.js
@@ -1,6 +1,5 @@
 import path from 'path'
 import webpack from 'webpack'
-import postCSSModulesValues from 'postcss-modules-values'
 import ExtractTextPlugin from 'extract-text-webpack-plugin'
 import autoprefixer from 'autoprefixer'
 import fileExtensions from '../../file-extensions'
@@ -95,11 +94,7 @@ export default {
           options: {
             postcss: {
               plugins: () => [
-                autoprefixer({ browsers }),
-
-                // allow importing values (variables) between css modules
-                // see: https://github.com/css-modules/postcss-modules-values#usage
-                postCSSModulesValues
+                autoprefixer({ browsers })
               ]
             }
           }

--- a/src/configure-webpack/loaders/style.js
+++ b/src/configure-webpack/loaders/style.js
@@ -39,6 +39,8 @@ export default {
       }
     }
 
+    const projectSourcePath = path.join(projectPath, 'src')
+
     const config = {
       ...defaultConfig,
       ...style
@@ -92,6 +94,13 @@ export default {
         new webpack.LoaderOptionsPlugin({
           debug: true,
           options: {
+            // Fixes an issue with colliding CSS Modules
+            // There is an integration test to validate it
+            // see:
+            //  - https://github.com/saguijs/sagui/issues/338
+            //  - https://github.com/webpack-contrib/css-loader/issues/413#issuecomment-283944881
+            context: projectSourcePath,
+
             postcss: [
               autoprefixer({ browsers })
             ]

--- a/src/configure-webpack/loaders/style.js
+++ b/src/configure-webpack/loaders/style.js
@@ -92,11 +92,9 @@ export default {
         new webpack.LoaderOptionsPlugin({
           debug: true,
           options: {
-            postcss: {
-              plugins: () => [
-                autoprefixer({ browsers })
-              ]
-            }
+            postcss: [
+              autoprefixer({ browsers })
+            ]
           }
         }),
 


### PR DESCRIPTION
- Drop support for relative path imports in nested SCSS files
- Remove support for shared variables in CSS
- Fix autoprefixer (broken in the current v9-rc) implementation (now with an integration test to back it up)
- Fix the CSS Modules collision issue (fix #338)