### PR TITLE
Do not try to write to package.json when there's no change

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "clean-webpack-plugin": "^0.1.16",
     "commander": "^2.9.0",
     "css-loader": "^0.28.0",
+    "deep-equal": "^1.0.1",
     "eslint": "^3.19.0",
     "eslint-config-prettier": "^1.7.0",
     "eslint-loader": "^1.7.1",

--- a/spec/integration/index.integration-spec.js
+++ b/spec/integration/index.integration-spec.js
@@ -65,6 +65,10 @@ describe('[integration] sagui', function () {
       fs.readFileSync(path.join(projectPath, '.editorconfig'))
     })
 
+    it('should add sagui scripts to the project', () => {
+      expect(JSON.parse(fs.readFileSync(path.join(projectPath, 'package.json'))).scripts.build).eql('sagui build')
+    })
+
     it('should not try to re-write packageJSON on new updates if content is the same', () => {
       fs.chmodSync(path.join(projectPath, 'package.json'), '0444')
       return sagui({ projectPath, action: actions.UPDATE })

--- a/spec/integration/index.integration-spec.js
+++ b/spec/integration/index.integration-spec.js
@@ -14,7 +14,7 @@ temp.track()
  * Simulate a complete install of Sagui in a target folder.
  *
  * It symlinks all the dependencies in place
- * and copies the require Sagui files.
+ * and copies the required Sagui files.
  */
 const npmInstall = (projectPath) => {
   const nodeModules = path.join(__dirname, '../../node_modules')
@@ -63,6 +63,11 @@ describe('[integration] sagui', function () {
       fs.readFileSync(path.join(projectPath, '.gitignore'))
       fs.readFileSync(path.join(projectPath, '.flowconfig'))
       fs.readFileSync(path.join(projectPath, '.editorconfig'))
+    })
+
+    it('should not try to re-write packageJSON on new updates if content is the same', () => {
+      fs.chmodSync(path.join(projectPath, 'package.json'), '0444')
+      return sagui({ projectPath, action: actions.UPDATE })
     })
 
     describe('once we add content', () => {

--- a/spec/integration/index.integration-spec.js
+++ b/spec/integration/index.integration-spec.js
@@ -70,6 +70,7 @@ describe('[integration] sagui', function () {
     })
 
     it('should not try to re-write packageJSON on new updates if content is the same', () => {
+      // make the package.json read only
       fs.chmodSync(path.join(projectPath, 'package.json'), '0444')
       return sagui({ projectPath, action: actions.UPDATE })
     })

--- a/src/run/install/package-json.js
+++ b/src/run/install/package-json.js
@@ -6,8 +6,12 @@ export default function (projectPath) {
   const packagePath = path.join(projectPath, 'package.json')
   const packageJSON = json.read(packagePath)
 
-  json.write(packagePath, {
-    ...packageJSON,
-    scripts: updateNpmScripts(packageJSON.scripts)
-  })
+  const newScripts = updateNpmScripts(packageJSON.scripts)
+  const scriptsNeedsToBeUpdated = JSON.stringify(newScripts) !== JSON.stringify(packageJSON.scripts)
+  if (scriptsNeedsToBeUpdated) {
+    json.write(packagePath, {
+      ...packageJSON,
+      scripts: newScripts
+    })
+  }
 }

--- a/src/run/install/package-json.js
+++ b/src/run/install/package-json.js
@@ -8,7 +8,7 @@ export default function (projectPath) {
   const packageJSON = json.read(packagePath)
 
   const newScripts = updateNpmScripts(packageJSON.scripts)
-  if (deepEqual(newScripts, packageJSON.scripts)) {
+  if (!deepEqual(newScripts, packageJSON.scripts)) {
     json.write(packagePath, {
       ...packageJSON,
       scripts: newScripts

--- a/src/run/install/package-json.js
+++ b/src/run/install/package-json.js
@@ -1,4 +1,5 @@
 import path from 'path'
+import deepEqual from 'deep-equal'
 import updateNpmScripts from './update-npm-scripts'
 import json from '../../util/json'
 
@@ -7,8 +8,7 @@ export default function (projectPath) {
   const packageJSON = json.read(packagePath)
 
   const newScripts = updateNpmScripts(packageJSON.scripts)
-  const scriptsNeedsToBeUpdated = JSON.stringify(newScripts) !== JSON.stringify(packageJSON.scripts)
-  if (scriptsNeedsToBeUpdated) {
+  if (deepEqual(newScripts, packageJSON.scripts)) {
     json.write(packagePath, {
       ...packageJSON,
       scripts: newScripts


### PR DESCRIPTION
This specially needed for production deployment/compilation:
where the codebase is already configured (`package.json` already contains sagui scripts), but we need to install sagui again in the container/vm

Fixes #350 