### PR TITLE
Add support to override the supported browsers config - clean PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,25 @@ module.exports = {
 }
 ```
 
+
+### `browsers`
+
+List of browsers using the [browserslist format](https://github.com/ai/browserslist) that the target build must support.
+
+```js
+module.exports = {
+  browsers: [
+    '> 5%'
+  ]
+}
+```
+
+If not provided, the above default will be used instead.
+
+This information is used to decide the CSS prefixes to append.
+
+Internally Sagui uses [autoprefixer](https://github.com/postcss/autoprefixer).
+
 ### `style.cssModules`
 
 By default, styles compiled with Sagui will be output as [CSS Modules](https://github.com/css-modules), meaning they won't be global.

--- a/src/configure-webpack/loaders/style.js
+++ b/src/configure-webpack/loaders/style.js
@@ -19,7 +19,7 @@ const defaultConfig = {
  */
 export default {
   name: 'style',
-  configure ({ action, optimize, pages = [], projectPath, style = {} }) {
+  configure ({ action, optimize, pages = [], projectPath, style = {}, browsers }) {
     // Use null-loader during tests
     // for better performance
     if (action === actions.TEST_UNIT) {
@@ -78,7 +78,7 @@ export default {
         postCSSModulesValues,
 
         // Support browser prefixes for any browser with greater than 5% markeshare
-        autoprefixer({ browsers: ['> 5%'] })
+        autoprefixer({ browsers })
       ],
 
       module: {

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ export { MissingPackageJSON, SaguiPath } from './load-project-sagui-config'
 
 const DEFAULT_SAGUI_CONFIG = {
   port: 3000,
+  browsers: ['> 5%'],
   saguiPath: path.join(__dirname, '../'),
   optimize: false,
   coverage: false,


### PR DESCRIPTION
Enable overriding of the supported browsers configuration that will be used by autoprefixer.