### PR TITLE
Fix lint script not executing anything 😿

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -73,13 +73,17 @@ program.command('dist')
 
 program.command('test')
   .description('Run all the test checks (with coverage enabled)')
-  .action(setupAction('test', [actions.TEST_TYPECHECK, actions.TEST_UNIT]), { coverage: true })
+  .action(setupAction('test', [actions.TEST_LINT, actions.TEST_TYPECHECK, actions.TEST_UNIT]), { coverage: true })
 
 program.command('test:unit')
   .description('Run unit tests')
   .option('-w, --watch', 'Run tests on any file change')
   .option('-c, --coverage', 'Generate a coverage report')
   .action(setupAction('test', [actions.TEST_UNIT]))
+
+program.command('test:lint')
+  .description('Lint the code')
+  .action(setupAction('test', [actions.TEST_LINT]))
 
 program.command('test:typecheck')
   .description('Typecheck the code')


### PR DESCRIPTION
It was missing from the CLI.

This should fix the problem, but we should also make the CLI break if we try to run an action that is invalid. This would have made our “test create project” tests fail in Travis. We should make sure that is the case before merging this PR.

This fixes #358.