### PR TITLE
[RFC] Add handler for unknown commands

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -92,3 +92,8 @@ program.command('test:typecheck')
 program.command('update')
   .description('Update Sagui in the current project')
   .action(setupAction('development', [actions.UPDATE]))
+
+program.action(function () {
+  logError(`This action is not valid. Use --help to learn more about all the valid actions`)
+  process.exit(1)
+})


### PR DESCRIPTION
### Summary

Right now, as @pirelenito mentioned in #360 we need a handler for unknown actions, which cause the sagui to exit with non zero code, alerting the developers about the problems if any in their setup or sagui. This adds a very minimalistic solution in sagui.

However, I do have a few suggestions, we can use to improve this even further. I hope @pirelenito can look into it too after vacation. 
- Add helpful `Did you mean` messages, in order to tell the user, about the nearest matching option if any
- Maybe it should automatically redirect to `--help`

If the current solution is good enough, it's okay too. :+1: I am using exit code 1 in this case.