### PR TITLE
Improve ESLint integration in editors 📈

### DIFF
--- a/spec/integration/index.integration-spec.js
+++ b/spec/integration/index.integration-spec.js
@@ -22,9 +22,13 @@ const npmInstall = (projectPath) => {
 
   packages.forEach((name) => fs.ensureSymlinkSync(path.join(nodeModules, name), path.join(projectPath, 'node_modules', name)))
 
-  const saguiInNodeModules = path.join(projectPath, 'node_modules/sagui/karma-static-files')
-  fs.ensureDirSync(saguiInNodeModules)
-  fs.copySync(path.join(__dirname, '../../karma-static-files'), saguiInNodeModules)
+  const karmaStaticNodeModules = path.join(projectPath, 'node_modules/sagui/karma-static-files')
+  fs.ensureDirSync(karmaStaticNodeModules)
+  fs.copySync(path.join(__dirname, '../../karma-static-files'), karmaStaticNodeModules)
+
+  const libInNodeModules = path.join(projectPath, 'node_modules/sagui/lib')
+  fs.ensureDirSync(libInNodeModules)
+  fs.copySync(path.join(__dirname, '../../src/javascript-eslintrc.json'), path.join(libInNodeModules, 'javascript-eslintrc.json'))
 }
 
 describe('[integration] sagui', function () {

--- a/src/configure-webpack/loaders/javascript.js
+++ b/src/configure-webpack/loaders/javascript.js
@@ -74,7 +74,7 @@ export default {
             loader: 'eslint-loader',
             exclude: /node_modules/,
             options: {
-              configFile: path.join(__dirname, '../../javascript-eslintrc.json'),
+              configFile: path.join(projectPath, '.eslintrc'),
               useEslintrc: false,
               cwd: projectPath
             }

--- a/src/run/install/template.js
+++ b/src/run/install/template.js
@@ -28,6 +28,7 @@ function copyBase (projectPath) {
 
 function copyDotFiles (projectPath) {
   safeCopy(join(dotFilesPath, 'editorconfig'), join(projectPath, '.editorconfig'))
+  safeCopy(join(dotFilesPath, 'eslintrc'), join(projectPath, '.eslintrc'))
   safeCopy(join(dotFilesPath, 'flowconfig'), join(projectPath, '.flowconfig'))
   safeCopy(join(dotFilesPath, 'gitignore'), join(projectPath, '.gitignore'))
 }

--- a/src/run/lint.js
+++ b/src/run/lint.js
@@ -7,7 +7,7 @@ export default (saguiConfig) => new Promise((resolve, reject) => {
 
   const cli = new eslint.CLIEngine({
     cwd: projectPath,
-    configFile: path.join(__dirname, '../javascript-eslintrc.json'),
+    configFile: path.join(projectPath, '.eslintrc'),
     useEslintrc: false
   })
 

--- a/template/dot-files/eslintrc
+++ b/template/dot-files/eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "./node_modules/sagui/lib/javascript-eslintrc.json"
+}


### PR DESCRIPTION
Although originally, we wanted to have as little configuration files as possible in the root, having the `.eslintrc` allows for text editors to pickup the linter rules for inline errors.

This actually brings v9 closer to what we had in v8.