### PR TITLE
Mimic how Node scans for modules ©

### DIFF
--- a/spec/fixtures/project-with-node-modules/node_modules/dependencyA/index.js
+++ b/spec/fixtures/project-with-node-modules/node_modules/dependencyA/index.js
@@ -1,0 +1,5 @@
+var transientDependency = require('transient-dependency')
+
+module.exports = function () {
+  return transientDependency()
+}

--- a/spec/fixtures/project-with-node-modules/node_modules/dependencyA/node_modules/transient-dependency/index.js
+++ b/spec/fixtures/project-with-node-modules/node_modules/dependencyA/node_modules/transient-dependency/index.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+  return 'nested-dependency'
+}

--- a/spec/fixtures/project-with-node-modules/node_modules/dependencyB/index.js
+++ b/spec/fixtures/project-with-node-modules/node_modules/dependencyB/index.js
@@ -1,0 +1,5 @@
+var transientDependency = require('transient-dependency')
+
+module.exports = function () {
+  return transientDependency()
+}

--- a/spec/fixtures/project-with-node-modules/node_modules/ovewritten-by-node-modules/index.js
+++ b/spec/fixtures/project-with-node-modules/node_modules/ovewritten-by-node-modules/index.js
@@ -1,0 +1,3 @@
+export default function () {
+  return 'node-module'
+}

--- a/spec/fixtures/project-with-node-modules/node_modules/transient-dependency/index.js
+++ b/spec/fixtures/project-with-node-modules/node_modules/transient-dependency/index.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+  return 'root-dependency'
+}

--- a/spec/fixtures/project-with-node-modules/sagui.config.js
+++ b/spec/fixtures/project-with-node-modules/sagui.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  libraries: ['index'],
+}

--- a/spec/fixtures/project-with-node-modules/src/index.js
+++ b/spec/fixtures/project-with-node-modules/src/index.js
@@ -1,0 +1,9 @@
+import dependencyA from 'dependencyA'
+import dependencyB from 'dependencyB'
+import overwrittenByNodeModules from 'ovewritten-by-node-modules'
+
+export default {
+  dependencyB,
+  dependencyA,
+  overwrittenByNodeModules,
+}

--- a/spec/fixtures/project-with-node-modules/src/index.spec.js
+++ b/spec/fixtures/project-with-node-modules/src/index.spec.js
@@ -1,0 +1,12 @@
+import MyProject from '.'
+
+describe('transient dependencies', function() {
+  it('should get different versions of the same transient dependencies', function() {
+    expect(MyProject.dependencyA()).toEqual('nested-dependency')
+    expect(MyProject.dependencyB()).toEqual('root-dependency')
+  })
+
+  it('should get the node_modules file when requiring without absolute path', function() {
+    expect(MyProject.overwrittenByNodeModules()).toEqual('node-module')
+  })
+})

--- a/spec/fixtures/project-with-node-modules/src/ovewritten-by-node-modules.js
+++ b/spec/fixtures/project-with-node-modules/src/ovewritten-by-node-modules.js
@@ -1,0 +1,3 @@
+export default function() {
+  return 'src-module'
+}

--- a/spec/integration/index.integration-spec.js
+++ b/spec/integration/index.integration-spec.js
@@ -118,6 +118,17 @@ describe('[integration] sagui', function () {
       })
     })
 
+    describe('project with duplicated transient dependencies and colliding node_modules', () => {
+      const projectWithNodeModules = path.join(__dirname, '../fixtures/project-with-node-modules')
+      beforeEach(function () {
+        fs.copySync(projectWithNodeModules, projectPath, { overwrite: true })
+      })
+
+      it('should test that different dependencies get different transient dependencies and node_modules should win when colliding names', () => {
+        return sagui({ projectPath, action: actions.TEST_UNIT })
+      })
+    })
+
     describe('project with custom eslintrc', () => {
       const projectWithCustomEslintrc = path.join(__dirname, '../fixtures/project-with-custom-eslintrc')
       beforeEach(function () {

--- a/src/configure-webpack/index.js
+++ b/src/configure-webpack/index.js
@@ -98,9 +98,12 @@ const buildSharedWebpackConfig = (saguiConfig) => {
     resolve: {
       extensions: fileExtensions.list.JAVASCRIPT,
       modules: [
-        projectSourcePath,
+        // Keep same behavior as Node.js module resolution:
+        // - Precedence: `node_modules` win over `src`;
+        // - Scan modules by looking through the current directory and its ancestors.
+        'node_modules',
 
-        path.join(projectPath, '/node_modules'),
+        projectSourcePath,
 
         // Sagui node_modules is required in the path to be able
         // to load the `webpack-hot-middleware`


### PR DESCRIPTION
- Node modules takes precedence when colliding names;
- Respects nested dependencies (This safely allows multiple versions of the same library to co-exist in a project).

More information: https://webpack.js.org/configuration/resolve/#resolve-modules

**This will require a major version bump.**