### PR TITLE
Fix styles not being extract to a separated `css` file 🤒

### DIFF
--- a/spec/integration/index.integration-spec.js
+++ b/spec/integration/index.integration-spec.js
@@ -1,5 +1,6 @@
 import 'babel-polyfill'
 import { expect } from 'chai'
+import glob from 'glob'
 import fs from 'fs-extra'
 import path from 'path'
 import jsdom from 'jsdom'
@@ -55,6 +56,13 @@ describe('[integration] sagui', function () {
 
     it('should be possible to build', () => {
       return sagui({ projectPath, action: actions.BUILD })
+    })
+
+    it('should extract the styles in a separated file by default', () => {
+      return sagui({ projectPath, action: actions.BUILD }).then(() => {
+        const cssFiles = glob.sync(path.join(projectPath, 'dist/*.css'))
+        expect(cssFiles.length).to.eql(1)
+      })
     })
 
     it('should be possible to test', () => {

--- a/src/configure-webpack/index.js
+++ b/src/configure-webpack/index.js
@@ -21,8 +21,8 @@ export default (saguiConfig = {}) => {
   const { pages = [], libraries = [], ...sharedSaguiConfig } = saguiConfig
 
   const sharedWebpackConfig = merge.smart(
-    buildSharedWebpackConfig(sharedSaguiConfig),
-    buildLoadersConfig(sharedSaguiConfig),
+    buildSharedWebpackConfig(saguiConfig),
+    buildLoadersConfig(saguiConfig),
     sharedSaguiConfig.additionalWebpackConfig
   )
 

--- a/src/configure-webpack/loaders/style.js
+++ b/src/configure-webpack/loaders/style.js
@@ -19,7 +19,7 @@ const defaultConfig = {
  */
 export default {
   name: 'style',
-  configure ({ action, optimize, pages = [], projectPath, style = {}, browsers }) {
+  configure ({ action, optimize, pages, projectPath, style = {}, browsers }) {
     // Use null-loader during tests
     // for better performance
     if (action === actions.TEST_UNIT) {

--- a/src/configure-webpack/loaders/style.spec.js
+++ b/src/configure-webpack/loaders/style.spec.js
@@ -6,28 +6,28 @@ describe('style', function () {
   const projectPath = '/tmp/test-project'
 
   it('should have css modules enabled by default', () => {
-    const config = loader.configure({ projectPath })
+    const config = loader.configure({ projectPath, pages: [] })
 
     expect(config.module.rules[0].loader.includes('css-loader?modules')).to.eql(true)
     expect(config.module.rules[1].loader.includes('css-loader?modules')).to.eql(true)
   })
 
   it('should be possible to disable css modules', () => {
-    const config = loader.configure({ projectPath, style: { cssModules: false } })
+    const config = loader.configure({ projectPath, style: { cssModules: false }, pages: [] })
 
     expect(config.module.rules[0].loader.includes('css-loader?modules')).to.eql(false)
     expect(config.module.rules[1].loader.includes('css-loader?modules')).to.eql(false)
   })
 
   it('should have source maps disabled by default', () => {
-    const config = loader.configure({ projectPath })
+    const config = loader.configure({ projectPath, pages: [] })
 
     expect(config.module.rules[0].loader.includes('sourceMap')).to.eql(false)
     expect(config.module.rules[1].loader.includes('sourceMap')).to.eql(false)
   })
 
   it('should be possible to enable source maps', () => {
-    const config = loader.configure({ projectPath, style: { sourceMaps: true } })
+    const config = loader.configure({ projectPath, style: { sourceMaps: true }, pages: [] })
 
     expect(config.module.rules[0].loader.includes('sourceMap')).to.eql(true)
     expect(config.module.rules[1].loader.includes('sourceMap')).to.eql(true)
@@ -35,14 +35,14 @@ describe('style', function () {
 
   describe('extract text webpack plugin', () => {
     it('should be disabled by default', () => {
-      const config = loader.configure({ projectPath })
+      const config = loader.configure({ projectPath, pages: [] })
 
       expect(config.module.rules[0].loader.includes('css-loader')).to.eql(true)
       expect(config.module.rules[1].loader.includes('css-loader')).to.eql(true)
     })
 
     it('should be disabled on building NOT pages', () => {
-      const config = loader.configure({ projectPath, action: actions.BUILD })
+      const config = loader.configure({ projectPath, action: actions.BUILD, pages: [] })
 
       expect(config.module.rules[0].loader.includes('css-loader')).to.eql(true)
       expect(config.module.rules[1].loader.includes('css-loader')).to.eql(true)
@@ -65,7 +65,7 @@ describe('style', function () {
 
   describe('while running the tests', () => {
     it('should be a null loader for better performance', () => {
-      const config = loader.configure({ action: actions.TEST_UNIT })
+      const config = loader.configure({ action: actions.TEST_UNIT, pages: [] })
 
       expect(config.module.rules[0].loader).to.eql('null-loader')
       expect(config.module.rules[1].loader).to.eql('null-loader')


### PR DESCRIPTION
While refactoring the webpack configuration, we stopped sending the `pages` down to the loaders, which had the side-effect of us stopping configuring the extraction of styles.

Added an integration tests, and removed the default value for `pages`.