### PR TITLE
Load `babel-plugin-syntax-dynamic-import` plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "babel-cli": "^6.24.0",
     "babel-register": "^6.24.0",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "chai": "^3.5.0",
     "in-publish": "^2.0.0",
     "jsdom": "^9.12.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "devDependencies": {
     "babel-cli": "^6.24.0",
     "babel-register": "^6.24.0",
-    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "chai": "^3.5.0",
     "in-publish": "^2.0.0",
     "jsdom": "^9.12.0",
@@ -57,6 +56,7 @@
     "babel-eslint": "^7.2.1",
     "babel-loader": "^6.4.1",
     "babel-plugin-istanbul": "^4.1.1",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-react-jsx-self": "^6.22.0",
     "babel-plugin-transform-react-jsx-source": "^6.22.0",
     "babel-preset-env": "^1.3.3",

--- a/spec/fixtures/project-content-with-dynamic-import/src/index.js
+++ b/spec/fixtures/project-content-with-dynamic-import/src/index.js
@@ -1,0 +1,3 @@
+import('./lib').then(module => {
+  module()
+})

--- a/spec/fixtures/project-content-with-dynamic-import/src/lib.js
+++ b/spec/fixtures/project-content-with-dynamic-import/src/lib.js
@@ -1,0 +1,3 @@
+export default function() {
+  console.log('The lib is loaded')
+}

--- a/spec/integration/index.integration-spec.js
+++ b/spec/integration/index.integration-spec.js
@@ -39,6 +39,7 @@ describe('[integration] sagui', function () {
   const projectContentWithPrettierErrors = path.join(__dirname, '../fixtures/project-content-with-prettier-errors')
   const projectContentWithPrettierErrorsInSaguiConfig = path.join(__dirname, '../fixtures/project-content-with-prettier-errors-in-sagui-config')
   const projectContentCustomPrettierOptionsInEslintrc = path.join(__dirname, '../fixtures/project-content-with-custom-prettier-options-in-eslintrc')
+  const projectContentWithDynamicImports = path.join(__dirname, '../fixtures/project-content-with-dynamic-import')
   let projectPath, projectSrcPath
 
   beforeEach(function () {
@@ -360,6 +361,14 @@ npm-debug.log`)
       it('`format` should respect the prettier options from .eslintrc', async () => {
         await sagui({ projectPath, action: actions.FORMAT })
         await sagui({ projectPath, action: actions.TEST_LINT })
+      })
+    })
+
+    describe('when there are dynamic imports', () => {
+      it('`build` should not break', async () => {
+        fs.copySync(projectContentWithDynamicImports, projectPath, { overwrite: true })
+
+        await sagui({ projectPath, action: actions.BUILD })
       })
     })
   })

--- a/src/configure-webpack/loaders/javascript.js
+++ b/src/configure-webpack/loaders/javascript.js
@@ -45,13 +45,14 @@ export default {
                 require.resolve('babel-preset-stage-3')
               ],
               plugins: [
+                [require.resolve('babel-plugin-syntax-dynamic-import'), {}],
+
                 // Better React warnings and stack traces in development and testing
                 // Might no longer be needed in the future
                 // see: https://github.com/babel/babel/issues/4702
                 ...(action === actions.DEVELOP || action === actions.TEST_UNIT ? [
                   [require.resolve('babel-plugin-transform-react-jsx-source'), {}],
-                  [require.resolve('babel-plugin-transform-react-jsx-self'), {}],
-                  [require.resolve('babel-plugin-syntax-dynamic-import'), {}]
+                  [require.resolve('babel-plugin-transform-react-jsx-self'), {}]
                 ] : []),
 
                 ...(action === actions.TEST_UNIT && coverage ? [

--- a/src/configure-webpack/loaders/javascript.js
+++ b/src/configure-webpack/loaders/javascript.js
@@ -50,7 +50,8 @@ export default {
                 // see: https://github.com/babel/babel/issues/4702
                 ...(action === actions.DEVELOP || action === actions.TEST_UNIT ? [
                   [require.resolve('babel-plugin-transform-react-jsx-source'), {}],
-                  [require.resolve('babel-plugin-transform-react-jsx-self'), {}]
+                  [require.resolve('babel-plugin-transform-react-jsx-self'), {}],
+                  [require.resolve('babel-plugin-syntax-dynamic-import'), {}]
                 ] : []),
 
                 ...(action === actions.TEST_UNIT && coverage ? [


### PR DESCRIPTION
From Webpack2 we can use dynamic imports to asynchronously load modules in the project. Even Webpack will understands the `import()` statement, Babel will fail to parse this code if we don't install the appropriate plugins.
> Module build failed: SyntaxError: 'import' and 'export' may only appear at the top level

To avoid this issue, we can use the `babel-plugin-syntax-dynamic-imports`.
> This plugin only allows Babel to parse this syntax.
https://babeljs.io/docs/plugins/syntax-dynamic-import/