### PR TITLE
Non-intrusive ESLint messages while in development 🕺

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ matrix:
       node_js: 6.11.1
 
     # Test with PhantomJS available
-    - sudo: false
+    - dist: precise
+      sudo: false
       env:
         - TEST_TYPE=integration_test
         - BROWSER=PhantomJS

--- a/src/configure-webpack/loaders/javascript.js
+++ b/src/configure-webpack/loaders/javascript.js
@@ -81,7 +81,11 @@ export default {
             options: {
               configFile: path.join(projectPath, '.eslintrc'),
               useEslintrc: false,
-              cwd: projectPath
+              cwd: projectPath,
+
+              // While in development make the eslint messages non-intrusive
+              // by turning them all into warnings
+              emitWarning: action === actions.DEVELOP
             }
           },
           {

--- a/src/configure-webpack/loaders/javascript.spec.js
+++ b/src/configure-webpack/loaders/javascript.spec.js
@@ -1,6 +1,7 @@
 import path from 'path'
 import { expect } from 'chai'
 import loader from './javascript'
+import actions from '../../actions'
 
 describe('javaScript', () => {
   const projectPath = '/tmp/test-project'
@@ -11,6 +12,20 @@ describe('javaScript', () => {
 
     expect(webpack.module.rules[0].loader).to.eql('eslint-loader')
     expect(webpack.module.rules[0].enforce).to.eql('pre')
+  })
+
+  it('should emit all eslint warning/errors as warnings while in developmment', () => {
+    const projectPath = 'a/demo/path'
+    const webpack = loader.configure({ projectPath, action: actions.DEVELOP })
+
+    expect(webpack.module.rules[0].options.emitWarning).to.eql(true)
+  })
+
+  it('should emit normal eslint errors if not in development', () => {
+    const projectPath = 'a/demo/path'
+    const webpack = loader.configure({ projectPath, action: actions.BUILD })
+
+    expect(webpack.module.rules[0].options.emitWarning).to.eql(false)
   })
 
   it('should only build files inside the src folder by default', () => {


### PR DESCRIPTION
You still get the console errors, but no longer the build is prevented and neither a pop-up is displayed in the browser window.

Source: https://github.com/MoOx/eslint-loader/issues/23#issuecomment-86562996