### PR TITLE
Remove the DedupePlugin

### DIFF
--- a/src/configure-webpack/index.js
+++ b/src/configure-webpack/index.js
@@ -55,7 +55,6 @@ const buildSharedWebpackConfig = (saguiConfig) => {
       // only include the optimization plugins if
       // the flag is enabled
       ...(optimize ? [
-        new webpack.optimize.DedupePlugin(),
         new webpack.optimize.UglifyJsPlugin({
           sourceMap: true
         }),


### PR DESCRIPTION
Remove the DedupePlugin to prevent getting the following warning when optimized build is performed:

`WARNING in DedupePlugin: This plugin was removed from webpack. Remove it from your configuration.`