### PR TITLE
Remove the ModuleConcatenationPlugin

### DIFF
--- a/src/configure-webpack/index.js
+++ b/src/configure-webpack/index.js
@@ -58,7 +58,6 @@ const buildSharedWebpackConfig = (saguiConfig) => {
         new webpack.optimize.UglifyJsPlugin({
           sourceMap: true
         }),
-        new webpack.optimize.ModuleConcatenationPlugin(),
 
         // signal loaders to minimize
         // https://webpack.js.org/guides/migrating/#uglifyjsplugin-minimize-loaders


### PR DESCRIPTION
The `ModuleConcatenationPlugin` is messing up with the order of the polyfills in the production build, which causes errors.

The problem might be related to this issue in the plugin https://github.com/webpack/webpack/issues/5288

Let's stop using this plugin for now, until the issue is resolved.