### PR TITLE
Fix the sockjs-node connection errors while dev server is running

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "happypack": "^3.0.3",
     "html-loader": "^0.4.5",
     "html-webpack-plugin": "^2.28.0",
+    "ip": "^1.1.5",
     "jasmine-core": "^2.5.2",
     "karma": "^1.6.0",
     "karma-chrome-launcher": "^2.2.0",

--- a/src/run/development-server.js
+++ b/src/run/development-server.js
@@ -1,6 +1,7 @@
 import webpack from 'webpack'
 import { logError, log } from '../util/log'
 import Server from 'webpack-dev-server'
+import ip from 'ip'
 
 /**
  * Development server
@@ -14,7 +15,7 @@ export default (saguiConfig, webpackConfig) => new Promise((resolve, reject) => 
   }
 
   try {
-    const server = new Server(webpack(setupHMR(webpackConfig)), options)
+    const server = new Server(webpack(setupHMR(webpackConfig, saguiConfig.port)), options)
 
     server.listeningApp.on('error', function (e) {
       if (e.code === 'EADDRINUSE') {
@@ -42,16 +43,16 @@ export default (saguiConfig, webpackConfig) => new Promise((resolve, reject) => 
  * HMR bundle setup based on code from
  * https://github.com/webpack/webpack-dev-server/blob/master/bin/webpack-dev-server.js
  */
-function setupHMR (webpackConfig) {
+function setupHMR (webpackConfig, port) {
   return webpackConfig.map((webpack) => ({
     ...webpack,
-    entry: concatHMRBundle(webpack.entry)
+    entry: concatHMRBundle(webpack.entry, port)
   }))
 }
 
-function concatHMRBundle (entry) {
+function concatHMRBundle (entry, port) {
   const devClient = [
-    require.resolve('webpack-dev-server/client/') + '?/',
+    require.resolve('webpack-dev-server/client/') + `?http://${ip.address()}:${port}`,
     'webpack/hot/dev-server'
   ]
 


### PR DESCRIPTION
While the dev server is running the following errors are logged in the console.
<img width="746" alt="screen shot 2017-08-06 at 20 47 21" src="https://user-images.githubusercontent.com/2915276/29006293-3cbdc9ae-7aed-11e7-8b34-9db53aa6e5fc.png">

The solution suggested in this tread fixes the issue.
https://github.com/webpack/webpack-dev-server/issues/416#issuecomment-203484465