### PR TITLE
Set minChunks to 2 by default in CommonChunksPlugin

### DIFF
--- a/src/configure-webpack/build-pages-config.js
+++ b/src/configure-webpack/build-pages-config.js
@@ -43,7 +43,7 @@ function configurePlugins (pages, action) {
   })
 
   if (pages.length > 1) {
-    plugins.push(new optimize.CommonsChunkPlugin({ name: 'common' }))
+    plugins.push(new optimize.CommonsChunkPlugin({ name: 'common', minChunks: 2 }))
   }
 
   return plugins

--- a/src/configure-webpack/build-pages-config.spec.js
+++ b/src/configure-webpack/build-pages-config.spec.js
@@ -96,6 +96,13 @@ describe('pages webpack preset', function () {
       const commons = webpackConfig.plugins.filter((plugin) => plugin instanceof optimize.CommonsChunkPlugin)
       expect(commons.length).equal(1)
     })
+
+    it('should set minChunks to 2 in the CommonsChunkPlugin', function () {
+      const webpackConfig = buildPagesConfig(['index', 'demo'], baseConfig)
+
+      const commons = webpackConfig.plugins.filter((plugin) => plugin instanceof optimize.CommonsChunkPlugin)
+      expect(commons[0].minChunks).equal(2)
+    })
   })
 
   describe(`when action is "${actions.BUILD}"`, () => {


### PR DESCRIPTION
If a module is shared between two pages it should be moved into the commons chunk.

The current setup only moves modules to Commons if it shared between all pages.